### PR TITLE
Modify opening paragraph of create-charts.rst

### DIFF
--- a/data-visualization/charts/create-charts.rst
+++ b/data-visualization/charts/create-charts.rst
@@ -7,7 +7,7 @@ Create charts in Splunk Observability Cloud
 .. meta::
     :description: Plan and create charts in Splunk Observability Cloud
 
-Splunk Observability Cloud provides a number of built-in dashboards for services you integrate with Observability Cloud. These dashboards have charts that track key metrics for integrated services. In many cases, you don't have to create any additional charts or dashboards. However, if you do need a chart that isn't included in a built-in dashboard, see how to create a chart in the following sections.
+Splunk Observability Cloud provides a number of built-in dashboards for services you integrate with Observability Cloud. These dashboards have charts that track key metrics for integrated services. In many cases, you don't have to create any additional charts or dashboards. However, if you do need a chart that isn't included in a built-in dashboard, the following sections show you how to create a chart.
 
 Before you create a chart, you need to have an idea of which metrics you want to track. Metrics are added as signals on plot lines, or plots, on a chart. If you are unfamiliar with the metrics available, see :ref:`view-dashboards` to see which metrics are tracked in your organization's dashboards.
 


### PR DESCRIPTION
The second clause of the last sentence in the opening paragraph originally read:
> see how to create a chart in the following sections.
I think this language is clunky. We usually use the word "see" when we intend to point the reader to a specific section or topic. I changed the last sentence to read
> However, if you do need a chart that isn't included in a built-in dashboard, the following sections show you how to create a chart.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [ ] The content follows Splunk guidelines for style and formatting.
- [ ] There are no CLI errors when building the docs locally.
- [ ] You are contributing original content.

**Describe the change**
Enter a description of the change, why it's good for the docs, and so on.
