### PR TITLE
Add Windows 2022 to supported versions for ansible

### DIFF
--- a/gdi/opentelemetry/install-windows.rst
+++ b/gdi/opentelemetry/install-windows.rst
@@ -40,7 +40,7 @@ The Splunk Distribution of OpenTelemetry Collector for Windows has the following
    * - Windows installer (MSI)
      - Windows 2012, 2016, 2019, 2022
    * - Ansible
-     - Windows 2012, 2016, 2019
+     - Windows 2012, 2016, 2019, 2022
    * - Chef
      - Windows 2019, 2022
    * - Nomad


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [x] The content follows Splunk guidelines for style and formatting.
- [x] There are no CLI errors when building the docs locally.
- [x] You are contributing original content.

**Describe the change**
Splunk OpenTelemetry Collector - Add Windows 2022 to supported versions for ansible.