### PR TITLE
Update sso.rst

### DIFF
--- a/admin/SSO/sso.rst
+++ b/admin/SSO/sso.rst
@@ -42,10 +42,10 @@ A custom URL is required to allow users to log in to Observability Cloud from yo
 
 When you configure a login service integration and select :guilabel:`Show on login page`, the login details for the service appear on your organization's login page. You can have multiple SSO logins.
 
-You can allow users to log in to Observability Cloud using a custom URL that you've selected, such as `your_org.signalfx.com`. The URL will be a subdomain of signalfx.com. To set this up, contact :ref:`support` and provide the following:
+You can let users log in to Observability Cloud using a custom URL that you've selected, such as `your_org.signalfx.com`. The URL must be a subdomain of signalfx.com. To enable a custom URL, contact :ref:`support` and provide the following:
 
-- The URL (subdomain) you want to use.
-- The organization for which you want to use the custom url.
+- The subdomain you want to use.
+- The organization for which you want to use the custom URL.
 - An organization administrator's email address.
 
 .. _naming-note-sso:

--- a/admin/SSO/sso.rst
+++ b/admin/SSO/sso.rst
@@ -42,9 +42,9 @@ A custom URL is required to allow users to log in to Observability Cloud from yo
 
 When you configure a login service integration and select :guilabel:`Show on login page`, the login details for the service appear on your organization's login page. You can have multiple SSO logins.
 
-You can allow users to log in to Observability Cloud using a custom URL that you've selected, such as `your_org.example.com`. To set this up, contact :ref:`support` and provide the following:
+You can allow users to log in to Observability Cloud using a custom URL that you've selected, such as `your_org.signalfx.com`. The URL will be a subdomain of signalfx.com. To set this up, contact :ref:`support` and provide the following:
 
-- The URL you want to use.
+- The URL (subdomain) you want to use.
 - The organization for which you want to use the custom url.
 - An organization administrator's email address.
 


### PR DESCRIPTION
clarification about the subdomain, the example given ( your_org.example.com) is incorrect. The custom URL is always a subdomain of signalfx.com

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [ ] The content follows Splunk guidelines for style and formatting.
- [ ] There are no CLI errors when building the docs locally.
- [ ] You are contributing original content.

**Describe the change**
Enter a description of the change, why it's good for the docs, and so on.
