### PR TITLE
Update intro-profiling.rst

### DIFF
--- a/apm/profiling/intro-profiling.rst
+++ b/apm/profiling/intro-profiling.rst
@@ -54,7 +54,7 @@ For sample use cases, see :ref:`profiling-use-case-landingpage`.
     <h2>Memory profiling</h2>
   </embed>
 
-Memory profiling adds memory allocation data to stack traces and exposes JVM memory metrics, so that you can discover leaks and unusual consumption patterns in your instrumented services and applications. See :ref:`memory-profiling-use-case`.
+Memory profiling adds memory allocation data to stack traces and exposes memory metrics, so that you can discover leaks and unusual consumption patterns in your instrumented services and applications. See :ref:`memory-profiling-use-case`.
 
 After you get profiling data into Observability Cloud, you can visualize the memory allocation behavior of each component using the flame graph. See :ref:`flamegraph-howto`.
 


### PR DESCRIPTION
removed "JVM" as an adjective for memory metrics because per doc feedback we also support Node.js and .NET memory profiling

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [ ] The content follows Splunk guidelines for style and formatting.
- [ ] There are no CLI errors when building the docs locally.
- [ ] You are contributing original content.

**Describe the change**
Enter a description of the change, why it's good for the docs, and so on.
