### PR TITLE
moving docs link to point to opentelemetry repo

### DIFF
--- a/infrastructure/network-explorer/network-explorer-metrics.rst
+++ b/infrastructure/network-explorer/network-explorer-metrics.rst
@@ -19,7 +19,7 @@ The following metrics are available to collect with Network Explorer.
 
 .. raw:: html
 
-    <div class="metrics-yaml" url="https://raw.githubusercontent.com/Flowmill/support/main/metrics.yaml"></div>
+    <div class="metrics-yaml" url="https://raw.githubusercontent.com/open-telemetry/opentelemetry-ebpf/main/docs/metrics/metrics.yaml"></div>
 
 Dimensions
 =============
@@ -28,7 +28,7 @@ The following dimensions are available for network telemetry metrics.
 
 .. raw:: html
 
-    <div class="metrics-yaml" url="https://raw.githubusercontent.com/Flowmill/support/main/dimensions.yaml"></div>
+    <div class="metrics-yaml" url="https://raw.githubusercontent.com/open-telemetry/opentelemetry-ebpf/main/docs/metrics/dimensions.yaml"></div>
 
 Customize metrics to collect
 ================================


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [ X] The content follows Splunk guidelines for style and formatting.
- [ X] There are no CLI errors when building the docs locally.
- [ X] You are contributing original content.

**Describe the change**
Enter a description of the change, why it's good for the docs, and so on.
Network Explorer metrics and dimension files have a new repository/location and this MR makes changes to point to the latest location.