### PR TITLE
Deprecate `process.cpu.utilization` for SFx for .NET

### DIFF
--- a/gdi/get-data-in/application/dotnet/configuration/dotnet-metrics-attributes.rst
+++ b/gdi/get-data-in/application/dotnet/configuration/dotnet-metrics-attributes.rst
@@ -85,7 +85,7 @@ The SignalFx Instrumentation for .NET can collect the following process metrics:
    * - ``process.cpu.time``
      - CumulativeCounter
      - Total CPU seconds broken down by different states, such as user and system.	
-   * - ``process.cpu.utilization``
+   * - ``process.cpu.utilization`` (deprecated)
      - Gauge
      - Difference in ``process.cpu.time`` since the last measurement, divided by the elapsed time and number of CPUs available to the process.
    * - ``process.threads``


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [x] The content follows Splunk guidelines for style and formatting.
- [x] There are no CLI errors when building the docs locally.
- [x] You are contributing original content.

**Describe the change**
Deprecate process.cpu.utilization for SFx for .NET
