### PR TITLE
Lambda go collector

### DIFF
--- a/gdi/get-data-in/serverless/aws/otel-lambda-layer/advanced-configuration.rst
+++ b/gdi/get-data-in/serverless/aws/otel-lambda-layer/advanced-configuration.rst
@@ -68,11 +68,11 @@ The following settings control trace exporters and their endpoints:
    * - ``OTEL_TRACES_EXPORTER``
      - Trace exporter to use. You can set multiple comma-separated values. Possible values are ``otlp`` and ``jaeger-thrift-splunk``.
    * - ``OTEL_EXPORTER_OTLP_ENDPOINT``
-     - The OTLP endpoint. When you set a value for the ``SPLUNK_REALM`` environment variable, the default endpoint is in the form ``https://ingest.<realm>.signalfx.com/v2/trace/otlp``.
+     - The OTLP endpoint. This defaults to the collector running on localhost, ``http://localhost:4318``.
    * - ``OTEL_EXPORTER_JAEGER_ENDPOINT``
      - The endpoint for the Jaeger exporter. When you set a value for the ``SPLUNK_REALM`` environment variable, the default endpoint is in the form ``https://ingest.<realm>.signalfx.com/v2/trace``.
 
-.. note:: Setting the exporter and the endpoint URL isn't required in most cases. By default, the layer sends telemetry directly to Observability Cloud ingest endpoints.
+.. note:: Setting the exporter and the endpoint URL isn't required in most cases. By default, the layer sends telemetry directly to a Collector run in the Lambda layer which sends the data to Observability Cloud ingest endpoints.
 
 .. _trace-propagation-configuration-lambda:
 

--- a/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
+++ b/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
@@ -9,8 +9,6 @@ Instrument your AWS Lambda function for Splunk Observability Cloud
 
 Use the Splunk OpenTelemetry Lambda Layer to automatically instrument your AWS Lambda functions for many programming languages. To get started, use the guided setup or follow the instructions manually.
 
-To send data to a Splunk OTel Collector in EC2, see :ref:`ec2-otel-collector-serverless`.
-
 Generate customized instructions using the guided setup
 ====================================================================
 
@@ -171,7 +169,7 @@ Follow these steps to add the required configuration for the Splunk OpenTelemetr
 
 To configure the mode of metric ingest, see :ref:`metrics-configuration-lambda`.
 
-.. note:: By default, the layer sends telemetry directly to Observability Cloud ingest endpoints. To send data to a Splunk OTel Collector in EC2, see :ref:`ec2-otel-collector-serverless`.
+.. note:: By default, the layer sends telemetry to a Collector instance on `localhost`.
 
 .. _go-serverless-instrumentation:
 
@@ -245,21 +243,12 @@ Each time the AWS Lambda function runs, trace and metric data appears in Splunk 
 
 .. _ec2-otel-collector-serverless:
 
-Send serverless spans through the Splunk OpenTelemetry Collector
+Send serverless spans directly to Splunk Observability Cloud
 =====================================================================
 
-By default, the Splunk OpenTelemetry Lambda Layer sends telemetry to Splunk Observability Cloud endpoints, without using a Collector. 
+By default, the Splunk OpenTelemetry Lambda Layer sends telemetry to a Collector running alongside the Lambda.
 
-Though not required, deploying a Splunk OTel Collector in the same virtual private cloud (VPC) of your Lambda can reduce latency in some cases.
+To send spans directly to Splunk Observability Cloud from an AWS Lambda function instrumented using the Splunk Lambda layer add the following environment variables:
 
-To send spans to the Splunk OTel Collector from an AWS Lambda function instrumented using the Splunk Lambda layer, follow these steps:
-
-#. Deploy the Collector in Gateway mode in a service your Lambda can reach, for example EC2. See :ref:`collector-gateway-mode`.
-#. Install the Splunk OTel Lambda layer. See :ref:`instrument-aws-lambda-functions`.
-#. Navigate to :guilabel:`Configuration` > :guilabel:`Environment variables`, then select :guilabel:`Edit`.
-#. As you're sending telemetry to the Collector, delete the ``SPLUNK_REALM`` environment variable.
-#. If you've already set the access token in the Collector configuration, delete the ``SPLUNK_ACCESS_TOKEN`` environment variable.
-#. Add the following environment variables:
-
-   -  ``OTEL_TRACES_EXPORTER`` with the value ``otlp_proto_http``
-   -  ``OTEL_EXPORTER_OTLP_ENDPOINT`` with the value ``<collector-gateway-ip-or-dns-name>:4318``
+- ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` with the value ``http/protobuf``
+- ``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` with the value ``https://ingest.<realm>.signalfx.com/v2/trace/otlp``, substituting ``<realm>`` with the name of your organization's realm.

--- a/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
+++ b/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
@@ -185,6 +185,8 @@ To instrument a Go function in AWS Lambda for Splunk APM, follow these additiona
       go get -u go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
       go get -u github.com/signalfx/splunk-otel-go/distro
 
+#. Set environment variable ``OTEL_EXPORTER_OTLP_ENDPOINT`` with the value ``http://localhost:4318`` and ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` with the value ``http/protobuf``.
+
 #. Create a wrapper for the OpenTelemetry instrumentation in your function's code. For example:
 
    .. code-block:: go


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [X] The content follows Splunk guidelines for style and formatting.
- [X] There are no CLI errors when building the docs locally.
- [X] You are contributing original content.

**Describe the change**

The Splunk Lambda layers now include the OTEL Collector and use it by default instead of posting directly to the cloud. These changes update the mentions of sending directly to instead refer to the localhost collector that will be running.
