### PR TITLE
Add Amazon Linux 2023 and RHEL 9 to supported distro list

### DIFF
--- a/gdi/opentelemetry/install-linux.rst
+++ b/gdi/opentelemetry/install-linux.rst
@@ -34,8 +34,8 @@ Installer script
 
 The following Linux distributions and versions are supported:
 
-* Amazon Linux: 2
-* CentOS, Red Hat, or Oracle: 7, 8
+* Amazon Linux: 2, 2023. Log collection with Fluentd is not currently supported for Amazon Linux 2023.
+* CentOS, Red Hat, or Oracle: 7, 8, 9
 * Debian: 9, 10, 11
 * SUSE: 12, 15 for versions v0.34.0 or higher. Log collection with Fluentd is not currently supported.
 * Ubuntu: 16.04, 18.04, 20.04, and 22.04


### PR DESCRIPTION
**Requirements**
- [X] The content follows Splunk guidelines for style and formatting.
- [X] There are no CLI errors when building the docs locally.
- [X] You are contributing original content.

**Describe the change**
Add Amazon Linux 2023 and RHEL 9 to supported distro list for the linux installer script. Requires https://github.com/signalfx/splunk-otel-collector/pull/2865 to be released.
