### PR TITLE
Update splunk-hec-receiver.rst

### DIFF
--- a/gdi/opentelemetry/components/splunk-hec-receiver.rst
+++ b/gdi/opentelemetry/components/splunk-hec-receiver.rst
@@ -34,14 +34,14 @@ To activate the Splunk HEC receiver add a ``splunk_hec`` entry inside the ``rece
 
 .. code-block:: yaml
 
-   exporters:
+   receivers:
       splunk_hec:
 
 The following example shows a Splunk HEC receiver configured with all available settings:
 
 .. code-block:: yaml
 
-   exporters:
+   receivers:
      # ...
      splunk_hec:
      # Address and port the Splunk HEC receiver should bind to


### PR DESCRIPTION
fix yaml examples to modify the `receivers` section instead of `exporters`

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [x] The content follows Splunk guidelines for style and formatting.
- [x] There are no CLI errors when building the docs locally.
- [x] You are contributing original content.

**Describe the change**
The current Splunk HEC OTel Receiver docs page incorrectly references the `exporters` section of the yaml configuration instead of `receivers`. This will make it more clear where to add configuration details for the Splunk HEC Receiver.
