### PR TITLE
Order of multiple detectors example fix

### DIFF
--- a/gdi/opentelemetry/components/resourcedetection-processor.rst
+++ b/gdi/opentelemetry/components/resourcedetection-processor.rst
@@ -100,8 +100,8 @@ If multiple detectors insert the same attribute name, only the first detector is
 
 When using multiple detectors, follow this order:
 
-* AWS: ``gke``, ``gce``
-* GCP: ``lambda``, ``elastic_beanstalk``, ``eks``, ``ecs``, ``ec2``
+* AWS: ``lambda``, ``elastic_beanstalk``, ``eks``, ``ecs``, ``ec2``
+* GCP: ``gke``, ``gce``
 
 .. _resourcedetection-processor-metadata:
 


### PR DESCRIPTION
Multiple detectors usage examples were incorrect, for AWS it was GCP detectors, for GCP - the other way around

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [ ] The content follows Splunk guidelines for style and formatting.
- [ ] There are no CLI errors when building the docs locally.
- [ ] You are contributing original content.

**Describe the change**
Enter a description of the change, why it's good for the docs, and so on.
