### PR TITLE
Update hec options in install-windows.rst

### DIFF
--- a/gdi/opentelemetry/install-windows.rst
+++ b/gdi/opentelemetry/install-windows.rst
@@ -107,19 +107,19 @@ Configure fluentd for log collection
 -------------------------------------------
 
 By default, the installation configures the fluentd service to forward log events with the ``@SPLUNK`` label and
-send these events to the HEC ingest endpoint determined by the ``--realm <SPLUNK_REALM>`` option.
+send these events to the HEC ingest endpoint determined by the ``realm = "<SPLUNK_REALM>"`` option.
 For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
 
-To configure the package to send log events to a custom HTTP Event Collector (HEC) endpoint URL, you can specify the following parameters for the installer script:
+To configure the package to send log events to a custom HTTP Event Collector (HEC) endpoint URL with a token different than ``<SPLUNK_ACCESS_TOKEN>``, you can specify the following parameters for the installer script:
 
 * ``hec_url = "<SPLUNK_HEC_URL>"``
 * ``hec_token = "<SPLUNK_HEC_TOKEN>"``
 
-For example:
+For example (replace the ``<SPLUNK...>`` values in the command for your configuration):
 
 .. code-block:: PowerShell
 
-  & {Set-ExecutionPolicy Bypass -Scope Process -Force; $script = ((New-Object System.Net.WebClient).DownloadString('https://dl.signalfx.com/splunk-otel-collector.ps1')); $params = @{access_token = "SPLUNK_ACCESS_TOKEN"; realm = "SPLUNK_REALM"; hec_url = "SPLUNK_HEC_URL"; hec_token = "SPLUNK_HEC_TOKEN"}; Invoke-Command -ScriptBlock ([scriptblock]::Create(". {$script} $(&{$args} @params)"))}
+  & {Set-ExecutionPolicy Bypass -Scope Process -Force; $script = ((New-Object System.Net.WebClient).DownloadString('https://dl.signalfx.com/splunk-otel-collector.ps1')); $params = @{access_token = "<SPLUNK_ACCESS_TOKEN>"; realm = "<SPLUNK_REALM>"; hec_url = "<SPLUNK_HEC_URL>"; hec_token = "<SPLUNK_HEC_TOKEN>"}; Invoke-Command -ScriptBlock ([scriptblock]::Create(". {$script} $(&{$args} @params)"))}
 
 The installation creates the main fluentd configuration file  ``<drive>\opt\td-agent\etc\td-agent\td-agent.conf``, where ``<drive>`` is the drive letter for the fluentd installation directory.
 

--- a/gdi/opentelemetry/install-windows.rst
+++ b/gdi/opentelemetry/install-windows.rst
@@ -112,8 +112,14 @@ For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
 
 To configure the package to send log events to a custom HTTP Event Collector (HEC) endpoint URL, you can specify the following parameters for the installer script:
 
-* ``SPLUNK_HEC_URL = "<URL>"``
-* ``SPLUNK_HEC_TOKEN = "<TOKEN>"``
+* ``hec_url = "<SPLUNK_HEC_URL>"``
+* ``hec_token = "<SPLUNK_HEC_TOKEN>"``
+
+For example:
+
+.. code-block:: PowerShell
+
+  & {Set-ExecutionPolicy Bypass -Scope Process -Force; $script = ((New-Object System.Net.WebClient).DownloadString('https://dl.signalfx.com/splunk-otel-collector.ps1')); $params = @{access_token = "SPLUNK_ACCESS_TOKEN"; realm = "SPLUNK_REALM"; hec_url = "SPLUNK_HEC_URL"; hec_token = "SPLUNK_HEC_TOKEN"}; Invoke-Command -ScriptBlock ([scriptblock]::Create(". {$script} $(&{$args} @params)"))}
 
 The installation creates the main fluentd configuration file  ``<drive>\opt\td-agent\etc\td-agent\td-agent.conf``, where ``<drive>`` is the drive letter for the fluentd installation directory.
 


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [x] The content follows Splunk guidelines for style and formatting.
- [x] There are no CLI errors when building the docs locally.
- [x] You are contributing original content.

**Describe the change**
Fix custom HEC url and token options for the windows installer script, and add an example.  Similar change as https://github.com/signalfx/splunk-otel-collector/pull/3003.
