### PR TITLE
Fix syntax of the permission for CW Metric Streams

### DIFF
--- a/gdi/get-data-in/connect/aws/aws-apiconfig.rst
+++ b/gdi/get-data-in/connect/aws/aws-apiconfig.rst
@@ -169,15 +169,15 @@ For example:
       "Effect": "Allow",
       "Action": [
         "cloudwatch:GetMetricStream",       
-        "cloudwatch:ListMetrics"
+        "cloudwatch:ListMetrics",
         "cloudwatch:ListMetricStreams",
         "cloudwatch:PutMetricStream",
         "cloudwatch:DeleteMetricStream",
         "cloudwatch:StartMetricStreams",
-        "cloudwatch:StopMetricStreams"
+        "cloudwatch:StopMetricStreams",
         "ec2:DescribeRegions",
         "organizations:DescribeOrganization",
-        "tag:GetResources",
+        "tag:GetResources"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**
- [x] The content follows Splunk guidelines for style and formatting.
- [ ] There are no CLI errors when building the docs locally.
- [ ] You are contributing original content.

**Describe the change**
I added the missing commas and removed one extra comma