### PR TITLE
Update docs according to rum 0.15.0 release

### DIFF
--- a/gdi/get-data-in/rum/browser/browser-rum-instrumentations.rst
+++ b/gdi/get-data-in/rum/browser/browser-rum-instrumentations.rst
@@ -196,6 +196,9 @@ The Browser RUM agent collects the following data using the ``webvitals`` instru
    * - ``cls``
      - Cumulative Layout Shift
      - Measures visual stability by capturing the sum of all individual layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page. A layout shift occurs any time a visible element changes its position from one rendered frame to the next.
+   * - ``inp``
+     - Interaction to Next Paint
+     - Measures responsiveness by observing the latency of all interactions a user has done on the page and reports the value which most interactions were faster of.
 
 .. _browser-rum-data-resources-after-load:
 

--- a/gdi/get-data-in/rum/browser/browser-rum-instrumentations.rst
+++ b/gdi/get-data-in/rum/browser/browser-rum-instrumentations.rst
@@ -198,7 +198,7 @@ The Browser RUM agent collects the following data using the ``webvitals`` instru
      - Measures visual stability by capturing the sum of all individual layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page. A layout shift occurs any time a visible element changes its position from one rendered frame to the next.
    * - ``inp``
      - Interaction to Next Paint
-     - Measures responsiveness by observing the latency of all interactions a user has done on the page and reports the value which most interactions were faster of.
+     - Measures responsiveness by observing the latency of all interactions a user has done on the page and reports the slowest value.
 
 .. _browser-rum-data-resources-after-load:
 

--- a/gdi/get-data-in/rum/browser/configure-rum-browser-instrumentation.rst
+++ b/gdi/get-data-in/rum/browser/configure-rum-browser-instrumentation.rst
@@ -72,7 +72,7 @@ Use the following settings to configure the Browser RUM agent:
      - Domain used for session tracking. For example, if you have sites on both ``foo.example.com`` and ``bar.example.com``, setting ``cookieDomain`` to ``example.com`` allows both sites to use the same session identifier. See :ref:`browser-rum-cookies` for more information.
    * - ``context.async``
      - Boolean
-     - Activates the asynchronous context manager. The default value is ``false``. See :ref:`browser-rum-async-traces`.
+     - Activates the asynchronous context manager. The default value is ``true``. See :ref:`browser-rum-async-traces`.
    * - ``exporter.onAttributesSerializing``
      - ``(a: SpanAttributes, s?: Span) => SpanAttributes``
      - Provides a callback for modifying span attributes before they're exported. The default value is ``(attrs) => attrs``. A sample use case is :ref:`rum-browser-redact-pii`. 
@@ -314,7 +314,7 @@ Traces that happen asynchronously, such as user interactions that result in a pr
 -  ``MessagePort``
 -  Hash-based routers
 
-To activate asynchronous traces, set the ``context.async`` property to ``true``.
+To asynchronous trace linking is enabled by default. In case of compatibility issues you can disable it by setting the ``context.async`` property to ``false``.
 
 The context manager allows Splunk RUM to link requests executed when a component is first rendered to the user interaction that caused the application to add the component to the page. ``XMLHttpRequest`` events and Fetch API events through promise methods are patched to preserve the parent context, so subsequent requests link to their parents.
 
@@ -323,7 +323,7 @@ Limitations
 
 The following limitations apply when using asynchronous tracing:
 
-- ``async/await`` functions aren't supported. You can connect them using Babel as in the following example:
+- ``async/await`` functions aren't supported. You down-compile the code using Babel and targeting older browsers.
 
    .. code-block:: javascript
 

--- a/gdi/get-data-in/rum/browser/configure-rum-browser-instrumentation.rst
+++ b/gdi/get-data-in/rum/browser/configure-rum-browser-instrumentation.rst
@@ -314,7 +314,7 @@ Traces that happen asynchronously, such as user interactions that result in a pr
 -  ``MessagePort``
 -  Hash-based routers
 
-To asynchronous trace linking is enabled by default. In case of compatibility issues you can disable it by setting the ``context.async`` property to ``false``.
+Asynchronous trace linking is activated by default. In case of compatibility issues you can disable it by setting the ``context.async`` property to ``false``.
 
 The context manager allows Splunk RUM to link requests executed when a component is first rendered to the user interaction that caused the application to add the component to the page. ``XMLHttpRequest`` events and Fetch API events through promise methods are patched to preserve the parent context, so subsequent requests link to their parents.
 
@@ -323,7 +323,7 @@ Limitations
 
 The following limitations apply when using asynchronous tracing:
 
-- ``async/await`` functions aren't supported. You down-compile the code using Babel and targeting older browsers.
+- ``async/await`` functions aren't supported. Down-compile the code using Babel and targeting older browsers.
 
    .. code-block:: javascript
 


### PR DESCRIPTION
Update documentation according to changes in [0.15.0-rc.0](https://github.com/signalfx/splunk-otel-js-web/releases/tag/v0.15.0-rc.0) -> 0.15.0 releases of RUM