### PR TITLE
Update Node.js version for Lambda

### DIFF
--- a/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
+++ b/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
@@ -48,7 +48,7 @@ The Splunk OpenTelemetry Lambda Layer supports the following runtimes in AWS Lam
 
 - Java 8 and 11
 - Python 3.8 and 3.9
-- Node.js >= 14
+- Node.js 14 and higher
 - Ruby 2.7
 - Go 1.18
 

--- a/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
+++ b/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
@@ -48,7 +48,7 @@ The Splunk OpenTelemetry Lambda Layer supports the following runtimes in AWS Lam
 
 - Java 8 and 11
 - Python 3.8 and 3.9
-- Node.js 10, 12, and 14
+- Node.js >= 14
 - Ruby 2.7
 - Go 1.18
 


### PR DESCRIPTION
**Requirements**
- [x] The content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**
OpenTelemetry supports Node.js 14 and up (thus it's the same for our distro). The previous versions should work as well (we don't test it though), but OTel has dropped official support for these