### PR TITLE
Remove mentions of java jaeger configuration 

### DIFF
--- a/gdi/get-data-in/application/java/configuration/advanced-java-otel-configuration.rst
+++ b/gdi/get-data-in/application/java/configuration/advanced-java-otel-configuration.rst
@@ -110,15 +110,11 @@ The following settings control trace exporters and their endpoints:
    * - Environment variable
      - Description
    * - ``OTEL_TRACES_EXPORTER``
-     - Trace exporter to use. You can set multiple comma-separated values. For example, ``otlp,console_span``. The default value is ``otlp``. To select the Jaeger exporter, use ``jaeger-thrift-splunk``. |br| |br| System property: ``otel.traces.exporter``
+     - Trace exporter to use. You can set multiple comma-separated values. |br| |br| System property: ``otel.traces.exporter``
    * - ``OTEL_EXPORTER_OTLP_ENDPOINT``
      - OTLP gRPC endpoint. The default value is ``http://localhost:4317``. |br| |br| System property: ``otel.exporter.otlp.endpoint``
-   * - ``OTEL_EXPORTER_JAEGER_ENDPOINT``
-     - The Jaeger endpoint. The default value is ``http://localhost:9080/v1/trace``. |br| |br| System property: ``otel.exporter.jaeger.endpoint``
 
-The Splunk Distribution of OpenTelemetry Java uses the OTLP gRPC span exporter by default. If you're still using the Smart Agent (now deprecated), use the Jaeger exporter. To send data directly to Splunk Observability Cloud, see :ref:`export-directly-to-olly-cloud-java`.
-
-.. caution:: Support for the `jaeger-thrift-splunk` exporter will be removed after December 17th, 2022.
+The Splunk Distribution of OpenTelemetry Java uses the OTLP gRPC span exporter by default. To send data directly to Splunk Observability Cloud, see :ref:`export-directly-to-olly-cloud-java`.
 
 .. _trace-sampling-settings-java:
 

--- a/gdi/get-data-in/application/java/troubleshooting/common-java-troubleshooting.rst
+++ b/gdi/get-data-in/application/java/troubleshooting/common-java-troubleshooting.rst
@@ -110,42 +110,6 @@ To troubleshoot the lack of connectivity between the OTLP exporter and the OTel 
 #. Check that the OTLP gRPC receiver is activated in the OTel Collector and plugged into the traces pipeline.
 #. Check that the OTel Collector points to the following address: ``http://<host>:4317``. Verify that your URL is correct.
 
-Channel pipeline error
--------------------------------------------------------------------
-
-If you're seeing the following error in your logs, it might mean that the Java agent is trying to send trace data to the Splunk ingest API endpoint, which is not yet supported by OTLP:
-
-.. code-block:: bash
-
-   [grpc-default-executor-1] ERROR io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter - Failed to export spans. Server is UNAVAILABLE. Make sure your collector is running and reachable from this network. Full error message:UNAVAILABLE: io exception
-   Channel Pipeline: [SslHandler#0, ProtocolNegotiators$ClientTlsHandler#0, WriteBufferingAndExceptionHandler#0, DefaultChannelPipeline$TailContext#0]
-
-To solve this issue, use the Jaeger exporter instead. See :ref:`trace-exporters-settings-java`.
-
-Jaeger can't export spans
-------------------------------------------------------
-
-The following warnings in your logs mean that the Java agent can't send trace data to the OTel Collector, the Smart Agent (now deprecated), or Splunk Cloud Platform using the Jaeger exporter:
-
-.. code-block:: bash
-
-   [BatchSpanProcessor_WorkerThread-1] WARN io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter - Failed to export spans
-   io.jaegertracing.internal.exceptions.SenderException: Could not send 8 spans
-      at io.jaegertracing.thrift.internal.senders.HttpSender.send(HttpSender.java:69)
-      ...
-   Caused by: java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:9080
-      at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265)
-      ...
-   Caused by: java.net.ConnectException: Connection refused (Connection refused)
-      ...
-
-To troubleshoot the lack of connectivity between Jaeger and Splunk Observability Cloud, try the following steps:
-
-1. Make sure that ``otel.exporter.jaeger.endpoint`` points to an OpenTelemetry Collector or Smart Agent instance, or to the Splunk Ingest URL. See :new-page:`Send data measurements <https://dev.splunk.com/observability/docs/apibasics/send_data_basics#Send-data-measurements>` in the Splunk Developer documentation.
-2. Check that the OpenTelemetry Collector or Smart Agent instance is configured and running.
-3. Check that the Jaeger Thrift HTTP receiver is activated and plugged into the traces pipeline. See :ref:`otel-exposed-endpoints`.
-4. Check that the endpoint is correct. The OpenTelemetry Collector or Smart Agent use different ports and paths by default. For the Jaeger receiver, the OTel Collector uses ``http://<host>:14268/api/traces``, while the Smart Agent uses ``http://<host>:9080/v1/trace``.
-
 401 error when sending spans
 --------------------------------------------------------
 

--- a/gdi/get-data-in/application/java/troubleshooting/migrate-signalfx-java-agent-to-otel.rst
+++ b/gdi/get-data-in/application/java/troubleshooting/migrate-signalfx-java-agent-to-otel.rst
@@ -7,7 +7,7 @@ Migrate from the SignalFx Java Agent
 .. meta:: 
    :description: The agent of the Splunk Distribution of OpenTelemetry Java replaces the deprecated SignalFx Java Agent. To migrate to the Splunk Java OTel agent, follow these instructions.
 
-The SignalFx Java Agent is deprecated and will reach End of Support on December 17th, 2022. Replace it with the agent from the Splunk Distribution of OpenTelemetry Java. For more information, see :ref:`smart-agent`.
+The SignalFx Java Agent is deprecated and has reached End of Support. Replace it with the agent from the Splunk Distribution of OpenTelemetry Java.
 
 The agent of the Splunk Distribution of OpenTelemetry Java is based on the OpenTelemetry Instrumentation for Java, an open-source project that uses the OpenTelemetry API and has a smaller memory footprint than the SignalFx Java Agent. 
 
@@ -55,7 +55,7 @@ The following table shows SignalFx Java Agent system properties and their OpenTe
    * - ``signalfx.env``
      - ``otel.resource.attributes=deployment.environment=<environment_name>``
    * - ``signalfx.endpoint.url``
-     - ``otel.exporter.otlp.endpoint`` or ``otel.exporter.jaeger.endpoint``, depending on which trace exporter you're using. OTLP is the default.
+     - ``otel.exporter.otlp.endpoint``
    * - ``signalfx.tracing.enabled``
      - ``otel.javaagent.enabled``
    * - ``signalfx.integration.<name>.enabled=false``
@@ -81,7 +81,7 @@ The following table shows SignalFx Java Agent environment variables and their Op
    * - ``SIGNALFX_ENV``
      - ``OTEL_RESOURCE_ATTRIBUTES=deployment.environment=<environment_name>``
    * - ``SIGNALFX_ENDPOINT_URL``
-     - ``OTEL_EXPORTER_OTLP_ENDPOINT`` or ``OTEL_EXPORTER_JAEGER_ENDPOINT``, depending on which trace exporter you're using. OTLP is the default one.
+     - ``OTEL_EXPORTER_OTLP_ENDPOINT``
    * - ``SIGNALFX_TRACING_ENABLED``
      - ``OTEL_JAVAAGENT_ENABLED``
    * - ``SIGNALFX_INTEGRATION_<name>_ENABLED=false``


### PR DESCRIPTION
In preparation of the Jaeger deprecation in a week, I thought it would be prudent to clean up the docs around this a little bit. It doesn't seem like we would want to explain to users how to configure something that no longer exists. This helps to establish OTLP as the recommended way forward.

This also picks up a few small cleanups related to exporters and the legacy signalfx java agent deprecation.

There were also some places that mentioned OTLP trace ingest not being supported, which I think is wrong (we've supported that for many months now, if not years).