### PR TITLE
Remove duplicate entry for serviceusage.services.use

### DIFF
--- a/gdi/get-data-in/connect/gcp/gcp.rst
+++ b/gdi/get-data-in/connect/gcp/gcp.rst
@@ -63,9 +63,6 @@ The following table specifies the permissions required for GCP integrations.
    *  - ``monitoring.timeSeries.list``
       - Yes
 
-   *  - ``serviceusage.services.use``
-      - Yes, if you want to activate the use of a quota from the project where metrics are stored
-
    *  - ``compute.instances.list``
       - Yes, if the Compute Engine service is activated
 


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

This change removes duplicated entry for the `serviceusage.services.use` permission.
