### PR TITLE
Update logging-exporter.rst

### DIFF
--- a/gdi/opentelemetry/components/logging-exporter.rst
+++ b/gdi/opentelemetry/components/logging-exporter.rst
@@ -82,8 +82,8 @@ The following example shows a logging exporter with detailed verbosity, which is
    exporters:
      logging:
        verbosity: detailed
-       sampling_initial: 5
-       sampling_thereafter: 200
+       sampling_initial: "5"
+       sampling_thereafter: "200"
 
 Settings
 ======================


### PR DESCRIPTION
Added double quotes in the example configuration. If these are not there, the OTel Collector crashes after a restart calling an incorrect configuration

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
