### PR TITLE
Update translation-tool.rst

### DIFF
--- a/gdi/opentelemetry/translation-tool.rst
+++ b/gdi/opentelemetry/translation-tool.rst
@@ -53,9 +53,9 @@ Collector config output
          type: load
       smartagent/memory:
          type: memory
-      exporters:
-         signalfx:
-            access_token: ${SFX_ACCESS_TOKEN}
+   exporters:
+      signalfx:
+         access_token: ${SFX_ACCESS_TOKEN}
             realm: us1
    service:
      pipelines:


### PR DESCRIPTION
Fixed indentation error at exporters section of Collector config output code block (it had been a subset of receivers but should be at same level, which it is now). Fix is in response to customer feedback.


**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
