### PR TITLE
Go: Remove otelbeego

### DIFF
--- a/gdi/get-data-in/application/go/go-otel-requirements.rst
+++ b/gdi/get-data-in/application/go/go-otel-requirements.rst
@@ -33,8 +33,6 @@ The Splunk Distribution of OpenTelemetry Go can instrument the following librari
      - :new-page:`httptrace <https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace>`
    * - runtime
      - :new-page:`runtime <https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/runtime/>`
-   * - github.com/astaxie/beego
-     - :new-page:`otelbeego <https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/astaxie/beego/otelbeego>`
    * - github.com/aws/aws-sdk-go-v2
      - :new-page:`otelaws <https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws>`
    * - github.com/bradfitz/gomemcache


### PR DESCRIPTION
`otelbeego` is no longer supported. See https://github.com/open-telemetry/opentelemetry-go-contrib/pull/4092 and https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4059.