### PR TITLE
OTL-2195: Fluentd disabled by default for installer scripts

### DIFF
--- a/gdi/opentelemetry/install-linux.rst
+++ b/gdi/opentelemetry/install-linux.rst
@@ -31,7 +31,7 @@ The following Linux distributions and versions are supported:
 The installer script deploys and configures these elements:
 
 * The Splunk Distribution of OpenTelemetry Collector for Linux
-* Fluentd, using the td-agent (disabled by default). See :ref:`fluentd-receiver` for more information
+* Fluentd, using the td-agent. Turned off by default. See :ref:`fluentd-receiver` for more information
 
 To install the package using the installer script, follow these steps:
 
@@ -95,14 +95,14 @@ To skip these steps and use configured repos on the target system that provide t
 Configure Fluentd
 ---------------------------------------
 
-To install Fluentd for log collection (disabled by default), run the installer script with the ``--with-fluentd`` option. For example:
+Fluentd is turned off by default. To install Fluentd for log collection, run the installer script with the ``--with-fluentd`` option. For example:
 
 .. code-block:: bash
 
    curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
    sudo sh /tmp/splunk-otel-collector.sh --with-fluentd --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
 
-When enabled, the Fluentd service is configured by default to collect and forward log events with the ``@SPLUNK`` label to the Collector, which then sends these events to the HEC ingest endpoint determined by the ``--realm <SPLUNK_REALM>`` option. For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
+When turned on, the Fluentd service is configured by default to collect and forward log events with the ``@SPLUNK`` label to the Collector, which then sends these events to the HEC ingest endpoint determined by the ``--realm <SPLUNK_REALM>`` option. For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
 
 The following Fluentd plugins are also installed:
 

--- a/gdi/opentelemetry/install-linux.rst
+++ b/gdi/opentelemetry/install-linux.rst
@@ -31,7 +31,7 @@ The following Linux distributions and versions are supported:
 The installer script deploys and configures these elements:
 
 * The Splunk Distribution of OpenTelemetry Collector for Linux
-* Fluentd, using the td-agent. See :ref:`fluentd-receiver` for more information
+* Fluentd, using the td-agent (disabled by default). See :ref:`fluentd-receiver` for more information
 
 To install the package using the installer script, follow these steps:
 
@@ -48,7 +48,7 @@ To install the package using the installer script, follow these steps:
    curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh;
    sudo sh /tmp/splunk-otel-collector.sh --realm SPLUNK_REALM --memory SPLUNK_MEMORY_TOTAL_MIB -- SPLUNK_ACCESS_TOKEN
 
-.. note:: If you don't have a Log Observer entitlement or don't wish to collect logs for the target host, use the ``--without-fluentd`` option to skip the installation of Fluentd when installing the Collector.
+.. note:: If you have a Log Observer entitlement or wish to collect logs for the target host with Fluentd, use the ``--with-fluentd`` option to also install Fluentd when installing the Collector.
 
 Run additional script options
 -------------------------------------------
@@ -95,10 +95,14 @@ To skip these steps and use configured repos on the target system that provide t
 Configure Fluentd
 ---------------------------------------
 
-.. note::
-   If you don't have a Log Observer entitlement or don't wish to collect logs for the target host, use the ``--without-fluentd`` option to skip the installation of Fluentd when installing the Collector.
+To install Fluentd for log collection (disabled by default), run the installer script with the ``--with-fluentd`` option. For example:
 
-By default, the Fluentd service is installed and configured to forward log events with the ``@SPLUNK`` label to the package, which then sends these events to the HEC ingest endpoint determined by the ``--realm <SPLUNK_REALM>`` option. For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
+.. code-block:: bash
+
+   curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
+   sudo sh /tmp/splunk-otel-collector.sh --with-fluentd --realm SPLUNK_REALM -- SPLUNK_ACCESS_TOKEN
+
+When enabled, the Fluentd service is configured by default to collect and forward log events with the ``@SPLUNK`` label to the Collector, which then sends these events to the HEC ingest endpoint determined by the ``--realm <SPLUNK_REALM>`` option. For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
 
 The following Fluentd plugins are also installed:
 
@@ -123,8 +127,8 @@ RPM-based systems:
 
 You can specify the following parameters to configure the package to send log events to a custom Splunk HTTP Event Collector (HEC) endpoint URL:
 
-* ``hec-url = "<URL>"``
-* ``hec-token = "<TOKEN>"``
+* ``--hec-url <URL>``
+* ``--hec-token <TOKEN>``
 
 HEC lets you send data and application events to a Splunk deployment over the HTTP and Secure HTTP (HTTPS) protocols. See :new-page:`Set up and use HTTP Event Collector in Splunk Web <https://docs.splunk.com/Documentation/Splunk/8.2.1/Data/UsetheHTTPEventCollector>.`
 

--- a/gdi/opentelemetry/install-windows.rst
+++ b/gdi/opentelemetry/install-windows.rst
@@ -57,7 +57,7 @@ depending on the installation method:
 Installer script
 ==========================
 
-The installer script is available for Windows 64-bit environments, and deploys and configures the Splunk Distribution of OpenTelemetry Collector for Windows and Fluentd (using the td-agent).
+The installer script is available for Windows 64-bit environments, and deploys and configures the Splunk Distribution of OpenTelemetry Collector for Windows and Fluentd (using the td-agent, disabled by default).
 
 To install the package using the installer script, follow these steps:
 
@@ -99,7 +99,13 @@ To configure proxy settings to install and run the OpenTelemetry Collector, see 
 Configure fluentd for log collection
 -------------------------------------------
 
-By default, the installation configures the fluentd service to forward log events with the ``@SPLUNK`` label and
+If you have a Log Observer entitlement or wish to collect logs for the target host with Fluentd, use the ``with_fluentd = 1`` option to also install Fluentd when installing the Collector. For example:
+
+.. code-block:: PowerShell
+
+  & {Set-ExecutionPolicy Bypass -Scope Process -Force; $script = ((New-Object System.Net.WebClient).DownloadString('https://dl.signalfx.com/splunk-otel-collector.ps1')); $params = @{access_token = "SPLUNK_ACCESS_TOKEN"; realm = "SPLUNK_REALM"; with_fluentd = 1}; Invoke-Command -ScriptBlock ([scriptblock]::Create(". {$script} $(&{$args} @params)"))}
+
+When enabled, the Fluentd service is configured by default to collect and forward log events with the ``@SPLUNK`` label to the Collector, which then
 send these events to the HEC ingest endpoint determined by the ``realm = "<SPLUNK_REALM>"`` option.
 For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
 

--- a/gdi/opentelemetry/install-windows.rst
+++ b/gdi/opentelemetry/install-windows.rst
@@ -57,7 +57,7 @@ depending on the installation method:
 Installer script
 ==========================
 
-The installer script is available for Windows 64-bit environments, and deploys and configures the Splunk Distribution of OpenTelemetry Collector for Windows and Fluentd (using the td-agent, disabled by default).
+The installer script is available for Windows 64-bit environments, and deploys and configures the Splunk Distribution of OpenTelemetry Collector for Windows and Fluentd through the td-agent, which is deactivated by default.
 
 To install the package using the installer script, follow these steps:
 
@@ -105,7 +105,7 @@ If you have a Log Observer entitlement or wish to collect logs for the target ho
 
   & {Set-ExecutionPolicy Bypass -Scope Process -Force; $script = ((New-Object System.Net.WebClient).DownloadString('https://dl.signalfx.com/splunk-otel-collector.ps1')); $params = @{access_token = "SPLUNK_ACCESS_TOKEN"; realm = "SPLUNK_REALM"; with_fluentd = 1}; Invoke-Command -ScriptBlock ([scriptblock]::Create(". {$script} $(&{$args} @params)"))}
 
-When enabled, the Fluentd service is configured by default to collect and forward log events with the ``@SPLUNK`` label to the Collector, which then
+When activated, the Fluentd service is configured by default to collect and forward log events with the ``@SPLUNK`` label to the Collector, which then
 send these events to the HEC ingest endpoint determined by the ``realm = "<SPLUNK_REALM>"`` option.
 For example, ``https://ingest.<SPLUNK_REALM>.signalfx.com/v1/log``.
 


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

Required when https://github.com/signalfx/splunk-otel-collector/pull/3369 is released, which will disable installation of fluentd by default.
