### PR TITLE
Update common-dotnet-troubleshooting.rst

### DIFF
--- a/gdi/get-data-in/application/dotnet/troubleshooting/common-dotnet-troubleshooting.rst
+++ b/gdi/get-data-in/application/dotnet/troubleshooting/common-dotnet-troubleshooting.rst
@@ -52,6 +52,8 @@ You can activate debug logging to obtain more information about the issue:
 
 You can change the default location by updating the ``SIGNALFX_TRACE_LOG_DIRECTORY`` environment variable. See :ref:`dotnet-debug-logging-settings` for more information and settings.
 
+If you've enabled debug logging and restarted the application, but you don't find any logs in the locations mentioned above, verify that other APM agents are not running or installed on the host as these will prevent the SignalFx Instrumentation for .NET from instrumenting the application. 
+
 .. note:: Activate debug logging only when needed. Debug mode requires more resources.
 
 Traces don't appear in Splunk Observability Cloud

--- a/gdi/get-data-in/application/dotnet/troubleshooting/common-dotnet-troubleshooting.rst
+++ b/gdi/get-data-in/application/dotnet/troubleshooting/common-dotnet-troubleshooting.rst
@@ -52,9 +52,9 @@ You can activate debug logging to obtain more information about the issue:
 
 You can change the default location by updating the ``SIGNALFX_TRACE_LOG_DIRECTORY`` environment variable. See :ref:`dotnet-debug-logging-settings` for more information and settings.
 
-If you've enabled debug logging and restarted the application, but you don't find any logs in the locations mentioned above, verify that other APM agents are not running or installed on the host as these will prevent the SignalFx Instrumentation for .NET from instrumenting the application. 
+..note:: If you've enabled debug logging and restarted the application, but you don't find any logs in the previous locations, check that other APM agents aren't running or aren't installed on the host. Multiple APM agents might prevent the SignalFx Instrumentation for .NET from instrumenting the application. 
 
-.. note:: Activate debug logging only when needed. Debug mode requires more resources.
+.. caution:: Activate debug logging only when needed. Debug mode requires more resources.
 
 Traces don't appear in Splunk Observability Cloud
 ==================================================================


### PR DESCRIPTION
**Requirements**

- [ X ] Content follows Splunk guidelines for style and formatting.
- [ X ] You are contributing original content.

**Describe the change**

We ran into several issues working with a customer where the presence of another vendor's APM agent in the environment prevented SignalFx .NET instrumentation from working, even though the other APM agent was not actively running. Nothing was written to the logs, and it took us time to figure out why instrumentation wasn't working.

It would have been helpful to have some guidance on the .NET troubleshooting page to tell us what to check if the logs folder is empty.
