### PR TITLE
Remove spaces that break :guilabel:

### DIFF
--- a/gdi/get-data-in/application/java/instrumentation/java-servers-instructions.rst
+++ b/gdi/get-data-in/application/java/instrumentation/java-servers-instructions.rst
@@ -169,10 +169,10 @@ WebSphere Traditional
 
 Open the WebSphere Admin Console and follow these steps:
 
-#. Navigate to :guilabel:`Servers`, then :guilabel:` Server type`.
+#. Navigate to :guilabel:`Servers`, then :guilabel:`Server type`.
 #. Select :guilabel:`WebSphere application servers`.
 #. Select the desired server.
-#. Navigate to :guilabel:`Java and Process Management`, then :guilabel:` Process Definition`.
+#. Navigate to :guilabel:`Java and Process Management`, then :guilabel:`Process Definition`.
 #. Select :guilabel:`Java Virtual Machine`.
 #. In the :guilabel:`Generic JVM arguments` field, enter the path to Splunk Java agent:
 


### PR DESCRIPTION
There are some extra spaces that cause the formatting to be broken.

<img width="621" alt="image" src="https://github.com/splunk/public-o11y-docs/assets/75337021/9a533ae0-1b5b-4787-930f-9b6970dbc44e">
