### PR TITLE
Update kubernetes-config-logs.rst

### DIFF
--- a/gdi/opentelemetry/kubernetes-config-logs.rst
+++ b/gdi/opentelemetry/kubernetes-config-logs.rst
@@ -20,7 +20,7 @@ Add the following line to your configuration to use OpenTelemetry logs collectio
 
 The following are known limitations of native OpenTelemetry logs collection:
 
-* The ``service.name`` attribute is not automatically constructed in an Istio environment, which means that correlation between logs and traces does not work in Splunk Observability Cloud. Use Fluentd for logs collection if you deploy the Helm chart with ``autodetect.istio=true``.
+* With previous versions of the Splunk OpenTelemetry Collector, the ``service.name`` attribute was not automatically constructed in an Istio environment, which meant that correlation between logs and traces did not work in Splunk Observability Cloud. This was resolved with v0.80.0 of the Splunk OpenTelemetry collector <https://github.com/signalfx/splunk-otel-collector-chart/releases/tag/splunk-otel-collector-0.80.0>. If upgrading the collector to v0.80.0 or above is not possible, use Fluentd for logs collection if you deploy the Helm chart with ``autodetect.istio=true``.
 * Journald logs cannot be natively collected by the Collector at this time.
 * Logs collection is not supported in GKE Autopilot at this time.
 * See also :ref:`other rules and limitations for metrics and dimensions <metric-dimension-names>`. For instance, you can have up to 36 dimensions per MTS, otherwise the data point is dropped.

--- a/gdi/opentelemetry/kubernetes-config-logs.rst
+++ b/gdi/opentelemetry/kubernetes-config-logs.rst
@@ -20,7 +20,7 @@ Add the following line to your configuration to use OpenTelemetry logs collectio
 
 The following are known limitations of native OpenTelemetry logs collection:
 
-* With previous versions of the Splunk OpenTelemetry Collector, the ``service.name`` attribute was not automatically constructed in an Istio environment, which meant that correlation between logs and traces did not work in Splunk Observability Cloud. This was resolved with v0.80.0 of the Splunk OpenTelemetry collector <https://github.com/signalfx/splunk-otel-collector-chart/releases/tag/splunk-otel-collector-0.80.0>. If upgrading the collector to v0.80.0 or above is not possible, use Fluentd for logs collection if you deploy the Helm chart with ``autodetect.istio=true``.
+* You must use version 0.80.0 (or higher) of the Splunk OpenTelemetry collector <https://github.com/signalfx/splunk-otel-collector-chart/releases/tag/splunk-otel-collector-0.80.0>  to correlate logs and traces in Istio environments. If you are unable to upgrade the collector to version 0.80.0 or higher, use Fluentd for logs collection and deploy the Helm chart with ``autodetect.istio=true``.
 * Journald logs cannot be natively collected by the Collector at this time.
 * Logs collection is not supported in GKE Autopilot at this time.
 * See also :ref:`other rules and limitations for metrics and dimensions <metric-dimension-names>`. For instance, you can have up to 36 dimensions per MTS, otherwise the data point is dropped.


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ X ] Content follows Splunk guidelines for style and formatting.
- [ X ] You are contributing original content.

**Describe the change**

This page indicates that native OpenTelemetry logging doesn't work with Istio environments.  However, this issue has been resolved in v0.80.0 of the Splunk OpenTelemetry collector.  I've updated the doc to include this information. 
