### PR TITLE
otel-lambda: Update required Go version

### DIFF
--- a/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
+++ b/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
@@ -50,7 +50,7 @@ The Splunk OpenTelemetry Lambda Layer supports the following runtimes in AWS Lam
 - Python 3.8 and 3.9
 - Node.js 14 and higher
 - Ruby 2.7
-- Go 1.18
+- Go 1.19
 
 The Lambda Layer requires 49 MB on-disk in standard x86_64 systems.
 


### PR DESCRIPTION
Go 1.18 support is dropped since https://github.com/signalfx/splunk-otel-go/releases/tag/v1.6.0