### PR TITLE
set-up-logconnect.rst remove commas from integers

### DIFF
--- a/logs/set-up-logconnect.rst
+++ b/logs/set-up-logconnect.rst
@@ -79,7 +79,7 @@ In Splunk Enterprise, follow the instructions in the guided setup for the integr
          :width: 100%
          :alt: This screenshot shows recommended configuration for role search job limit and user search job limit.
 
-6. Now, in the :guilabel:`Role search time window limit` section of the :guilabel:`Resources` tab, select :guilabel:`Custom time` and enter 2,592,000 seconds (30 days) for the maximum time window for searches for this role. For the earliest searchable event time for this role,  select :guilabel:`Custom time` and enter 7,776,000 seconds (90 days). In the :guilabel:`Disk space limit` section enter a :guilabel:`Standard search limit` of 1000 MB.
+6. Now, in the :guilabel:`Role search time window limit` section of the :guilabel:`Resources` tab, select :guilabel:`Custom time` and enter 2592000 seconds (30 days) for the maximum time window for searches for this role. For the earliest searchable event time for this role,  select :guilabel:`Custom time` and enter 7776000 seconds (90 days). In the :guilabel:`Disk space limit` section enter a :guilabel:`Standard search limit` of 1000 MB.
 
       .. image:: /_images/logs/ResourcesTab2.png
          :width: 100%


### PR DESCRIPTION
In step 6 the values for "Role search time window limit" were not integers - they had commas in the numbers, which the Splunk app does not accept.  Removed the place-commas from the numbers 2,592,000 and 7,776,000

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
