### PR TITLE
Update instrument-nodejs-application.rst

### DIFF
--- a/gdi/get-data-in/application/nodejs/instrumentation/instrument-nodejs-application.rst
+++ b/gdi/get-data-in/application/nodejs/instrumentation/instrument-nodejs-application.rst
@@ -192,7 +192,7 @@ After you add the ``start()`` function to your entry point script, run your appl
 Add custom instrumentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To add custom or third-party instrumentations that implement the OpenTelemetry JS Instrumentation interface, pass them to ``startTracing()`` using the following code:
+To add custom or third-party instrumentations that implement the OpenTelemetry JS Instrumentation interface, pass them to ``start()`` using the following code:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
Updated deprecated `startTracing()` to `start()`

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
