### PR TITLE
Update advanced-nodejs-otel-configuration.rst

### DIFF
--- a/gdi/get-data-in/application/nodejs/configuration/advanced-nodejs-otel-configuration.rst
+++ b/gdi/get-data-in/application/nodejs/configuration/advanced-nodejs-otel-configuration.rst
@@ -105,7 +105,7 @@ For example, to turn off all default instrumentations and only turn on the ``bun
 
 .. code-block:: shell
 
-   export OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=true
+   export OTEL_INSTRUMENTATION_COMMON_DEFAULT_ENABLED=false
    export OTEL_INSTRUMENTATION_BUNYAN_ENABLED=true
 
 The previous settings only apply to instrumentations loaded by the Splunk Distribution of OpenTelemetry JS by default. When using the programmatic API to supply a list of user-specified instrumentations, they have no effect.


### PR DESCRIPTION
To only enable bunyan instrumentation, default enabled should be false.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
