### PR TITLE
Fix Go Lambda instrumentation

### DIFF
--- a/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
+++ b/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.rst
@@ -174,8 +174,6 @@ To instrument a Go function in AWS Lambda for Splunk APM, follow these additiona
       go get -u go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-lambda-go/otellambda
       go get -u github.com/signalfx/splunk-otel-go/distro
 
-#. Set environment variable ``OTEL_EXPORTER_OTLP_ENDPOINT`` with the value ``http://localhost:4318`` and ``OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`` with the value ``http/protobuf``.
-
 #. Create a wrapper for the OpenTelemetry instrumentation in your function's code. For example:
 
    .. code-block:: go


### PR DESCRIPTION
**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

@johnbley can you please review and test the changes?

I totally do not understand why we have this line. See: https://docs.splunk.com/observability/en/gdi/get-data-in/application/go/configuration/advanced-go-otel-configuration.html#advanced-go-otel-configuration

Take notice that our distro uses the OTLP over gRPC expoter. See https://github.com/signalfx/splunk-otel-go/blob/5b56d48059711131fe0eb3f833726e24bbf30a8d/distro/exporter.go#L25-L26. Is it a problem?

CC @RassK @theletterf
