### PR TITLE
Update runner -> runs in Private Location queue purging

### DIFF
--- a/synthetics/test-config/private-locations.rst
+++ b/synthetics/test-config/private-locations.rst
@@ -168,6 +168,6 @@ If your queue latency increases but your queue length doesn't, then try these tr
 
 The maximum number of runs in a queue is 100,000. 
 
-Any runners older than one hour are removed from the queue. 
+Any runs older than one hour are removed from the queue. 
 
 


### PR DESCRIPTION
**Requirements**

- [x ] Content follows Splunk guidelines for style and formatting.
- [ x] You are contributing original content.

**Describe the change**

Updates the Private Locations documentation for Synthetics to indicate that runs are removed from the queue, and not runners.