### PR TITLE
remove hard coded username from code example

### DIFF
--- a/gdi/monitors-databases/microsoft-sql-server.rst
+++ b/gdi/monitors-databases/microsoft-sql-server.rst
@@ -36,11 +36,11 @@ Microsoft SQL Server host. To create this login, follow these steps:
 
    USE master;
    GO
-   CREATE LOGIN [signalfxagent] WITH PASSWORD = '<YOUR PASSWORD HERE>';
+   CREATE LOGIN [<user_id>] WITH PASSWORD = '<YOUR PASSWORD HERE>';
    GO
-   GRANT VIEW SERVER STATE TO [signalfxagent];
+   GRANT VIEW SERVER STATE TO [<user_id>];
    GO
-   GRANT VIEW ANY DEFINITION TO [signalfxagent];
+   GRANT VIEW ANY DEFINITION TO [<user_id>];
    GO
 
 Configuration


### PR DESCRIPTION


<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ✅ ] Content follows Splunk guidelines for style and formatting.
- [ ✅ ] You are contributing original content.

**Describe the change**

The code example to setup the database uses a hard-coded user name. The config example to configure the integration shows the username can be set to any user. This change removes the hard coded username from the database setup example, to indicate the user is free to choose the name of the user for the integration.
