### PR TITLE
Update gcp-logs.rst

### DIFF
--- a/gdi/get-data-in/connect/gcp/gcp-logs.rst
+++ b/gdi/get-data-in/connect/gcp/gcp-logs.rst
@@ -28,7 +28,7 @@ To send GCP logs to Splunk Observability Cloud:
 
    - Change the token in the sample syntax (``token=your-splunk-hec-token``) to a Splunk Observability Cloud organization access token with ingest permission. For more information about organization access tokens, see :ref:`admin-org-tokens`.
 
-   - Change the URL in the sample syntax (``url=your-splunk-hec-url``) to point to the real-time log data ingest endpoint for Splunk Observability Cloud: ``https://ingest.{REALM}.signalfx.com``. For example, ``https://ingest.{REALM}.signalfx.com:443``.
+   - Change the URL in the sample syntax (``url=your-splunk-hec-url``) to point to the real-time log data ingest endpoint for Splunk Observability Cloud: ``https://ingest.{REALM}.signalfx.com/v1/log``.
 
 Manage delivery failures
 ------------------------------------------------


### PR DESCRIPTION
Fix the endpoint url to the correct log endpoint url as Azure/AWS.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

This is just a tiny fix on the retiring log collections from cloud providers page. I've checked with our engineers that this current URL is not the correct endpoint for log ingest.
