### PR TITLE
OTel Go distribution sends metrics directly to ingest

### DIFF
--- a/gdi/get-data-in/application/go/instrumentation/instrument-go-application.rst
+++ b/gdi/get-data-in/application/go/instrumentation/instrument-go-application.rst
@@ -182,4 +182,4 @@ In the ingest endpoint URL, ``realm`` is the Splunk Observability Cloud realm, f
 
 The realm name appears in the :guilabel:`Organizations` section. 
 
-For more information on the ingest API endpoints, see :new-page:`Send APM traces <https://dev.splunk.com/observability/docs/apm/send_traces/>` and `Send data points <https://dev.splunk.com/observability/docs/datamodel/ingest#Send-data-points>`.
+For more information on the ingest API endpoints, see :new-page:`Send APM traces <https://dev.splunk.com/observability/docs/apm/send_traces/>` and :new-page:`Send data points <https://dev.splunk.com/observability/docs/datamodel/ingest#Send-data-points>`.

--- a/gdi/get-data-in/application/go/instrumentation/instrument-go-application.rst
+++ b/gdi/get-data-in/application/go/instrumentation/instrument-go-application.rst
@@ -171,7 +171,6 @@ If you need to send data directly to Splunk Observability Cloud, set the followi
 
       $env:SPLUNK_ACCESS_TOKEN=<access_token>
       $env:SPLUNK_REALM=<realm>
-      $env:OTEL_METRICS_EXPORTER=none
 
 To obtain an access token, see :ref:`admin-api-access-tokens`.
 
@@ -183,6 +182,4 @@ In the ingest endpoint URL, ``realm`` is the Splunk Observability Cloud realm, f
 
 The realm name appears in the :guilabel:`Organizations` section. 
 
-For more information on the ingest API endpoints, see :new-page:`Send APM traces <https://dev.splunk.com/observability/docs/apm/send_traces/>`.
-
-.. note:: Currently, you can't bypass the Collector to send metrics directly to Splunk Observability Cloud.
+For more information on the ingest API endpoints, see :new-page:`Send APM traces <https://dev.splunk.com/observability/docs/apm/send_traces/>` and `Send data points <https://dev.splunk.com/observability/docs/datamodel/ingest#Send-data-points>`.


### PR DESCRIPTION
Follows https://github.com/signalfx/splunk-otel-go/releases/tag/v1.11.0