### PR TITLE
Update maven coordinates for upstream Android instrumentation

### DIFF
--- a/gdi/get-data-in/rum/android/install-rum-android.rst
+++ b/gdi/get-data-in/rum/android/install-rum-android.rst
@@ -111,7 +111,7 @@ Follow these steps to install the Android RUM agent using Maven Central:
             // Set the desired version of the RUM agent.
             // See available releases: https://github.com/signalfx/splunk-otel-android/releases
             implementation("com.splunk:splunk-otel-android:+")
-            implementation("com.splunk:opentelemetry-android-instrumentation:+")
+            implementation("io.opentelemetry.android:instrumentation:+")
          //...
          }
 
@@ -122,7 +122,7 @@ Follow these steps to install the Android RUM agent using Maven Central:
             // Set the desired version of the RUM agent.
             // See available releases: https://github.com/signalfx/splunk-otel-android/releases
             implementation 'com.splunk:splunk-otel-android:+'
-            implementation 'com.splunk:opentelemetry-android-instrumentation:+'
+            implementation 'io.opentelemetry.android:instrumentation:+'
          //...
          }
 


### PR DESCRIPTION
The coordinates for the android instrumentation are now sourced from opentelemetry.