### PR TITLE
Remove collector uninstall via WMI

### DIFF
--- a/gdi/opentelemetry/uninstall-the-collector.rst
+++ b/gdi/opentelemetry/uninstall-the-collector.rst
@@ -245,19 +245,6 @@ You can also uninstall the Collector for Windows using PowerShell:
 
 .. code-block:: PowerShell
 
-   # list installed programs to see if the Splunk OpenTelemetry Collector is installed
-   Get-WmiObject -Class Win32_Product | Select-Object -Property Name 
-
-   # if it exists, select the Collector 
-   $MyProgram = Get-WmiObject -Class Win32_Product | Where-Object{$_.Name -eq "Splunk OpenTelemetry Collector"}  
-   
-   # complete uninstall 
-   $MyProgram.uninstall()
-
-Alternatively, try the following commands:  
-
-.. code-block:: PowerShell
-
    $MyProgram = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\uninstall\* | Where { $_.DisplayName -eq "Splunk OpenTelemetry Collector" }
    
    cmd /c $MyProgram.UninstallString


### PR DESCRIPTION
**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

Simplify the instructions and avoids the uninstall using WMI given that sometimes the WMI record of the installed program can get corrupted. The instructions as given may cause a pop-up to show up to confirm the installation but that was true of the WMI instructions too.
