### PR TITLE
Add backslash escaping in the extract yaml example

### DIFF
--- a/gdi/opentelemetry/components/attributes-processor.rst
+++ b/gdi/opentelemetry/components/attributes-processor.rst
@@ -165,7 +165,7 @@ The following example shows how to create a new attribute based on the value of 
          # Creates four new attributes (defined in pattern) from the
          # value of the http.url attribute
        - key: "http.url"
-           pattern: ^(?P<http_protocol>.*):\/\/(?P<http_domain>.*)\/(?P<http_path>.*)(\?|\&)(?P<http_query_params>.*)
+           pattern: ^(?P<http_protocol>.*):\\/\\/(?P<http_domain>.*)\\/(?P<http_path>.*)(\\?|\\&)(?P<http_query_params>.*)
            action: extract
 
 Backfill spans that are missing an attribute


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

The extract yaml example didn't work on copy and paste as is, so I added backslash escaping.