### PR TITLE
page level metrics are captured only if custom URL grouping rules are…

### DIFF
--- a/gdi/get-data-in/rum/browser/rum-browser-data-model.rst
+++ b/gdi/get-data-in/rum/browser/rum-browser-data-model.rst
@@ -57,7 +57,7 @@ The following properties are common to all web applications instrumented for Spl
 
 Metrics 
 =================================
-The following tables list all of the metrics available in Splunk RUM for Browser. All errors in Splunk RUM have the dimension ``sf_error=true``. Metrics with the prefix ``rum.node.`` are page level metrics, whereas metrics with the prefix ``rum.`` are aggregations of multiple pages. Page level metrics also have a dimension ``sf_node_name``, which you can use to filter on specific pages.
+The following tables list all of the metrics available in Splunk RUM for Browser. All errors in Splunk RUM have the dimension ``sf_error=true``. Metrics with the prefix ``rum.node.`` are page level metrics, whereas metrics with the prefix ``rum.`` are aggregations of multiple pages. Page level metrics also have a dimension ``sf_node_name``, which you can use to filter on specific pages. Also, page level metrics are captured only if custom URL grouping rules are configured.
 
 
 .. list-table:: 


### PR DESCRIPTION
… configured

page level metrics are captured only if custom URL grouping rules are configured

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
