### PR TITLE
Update upstream-collector.rst

### DIFF
--- a/gdi/other-ingestion-methods/upstream-collector.rst
+++ b/gdi/other-ingestion-methods/upstream-collector.rst
@@ -71,10 +71,6 @@ The following table compares the Splunk Distribution of OpenTelemetry Collector 
     - Yes
     - Yes, when using Splunk exporters
 
-  * - RUM correlation
-    - Yes
-    - No
-
 Prerequisites
 ===================================================
 


### PR DESCRIPTION
The line item related to RUM correlation should be specific to the instrumentation libraries and not the Collector.

As per my understanding, the Splunk distribution of the OTel instrumentation libraries send the Server-Timing header. The header links spans from the browser with back-end spans.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
