### PR TITLE
Raise an error if the collector was already uninstalled

### DIFF
--- a/gdi/opentelemetry/collector-windows/windows-uninstall.rst
+++ b/gdi/opentelemetry/collector-windows/windows-uninstall.rst
@@ -26,5 +26,7 @@ You can also uninstall the Collector for Windows using PowerShell:
 .. code-block:: PowerShell
 
    $MyProgram = Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\uninstall\* | Where { $_.DisplayName -eq "Splunk OpenTelemetry Collector" }
-   
+
+   if (!$MyProgram) { throw "Splunk OpenTelemetry Collector is not installed" }
+
    cmd /c $MyProgram.UninstallString


### PR DESCRIPTION
**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

The uninstall command is silent if the collector was already uninstalled this can be confusing for users. This changes adds an error message to make clear if the collector was already uninstalled.
