### PR TITLE
Update intro-profiling.rst

### DIFF
--- a/apm/profiling/intro-profiling.rst
+++ b/apm/profiling/intro-profiling.rst
@@ -101,7 +101,7 @@ The following programming languages have instrumentation available:
    * - Python (in beta)
      - Splunk Distribution of OpenTelemetry Python version 1.15 or higher
 
-      Only CPU profiling is supported at the moment.
+       Only CPU profiling is supported.
      - * :ref:`instrument-python-applications`
        * :ref:`profiling-configuration-python`
 

--- a/apm/profiling/intro-profiling.rst
+++ b/apm/profiling/intro-profiling.rst
@@ -84,7 +84,6 @@ The following programming languages have instrumentation available:
    * - Node.js
      - Splunk Distribution of OpenTelemetry JS version 2.0 or higher
 
-       .NET versions 6.0 and higher are supported in AlwaysOn Profiling. .NET Framework is not supported. 
      - * :ref:`instrument-nodejs-applications`
        * :ref:`profiling-configuration-nodejs`
    * - .NET (OpenTelemetry)
@@ -95,10 +94,14 @@ The following programming languages have instrumentation available:
        * :ref:`profiling-configuration-otel-dotnet`
    * - .NET (SignalFx)
      - SignalFx Instrumentation for .NET version 1.0.0 or higher
+
+       .NET versions 6.0 and higher are supported in AlwaysOn Profiling. .NET Framework is not supported. 
      - * :ref:`instrument-dotnet-applications`
        * :ref:`profiling-configuration-dotnet`
    * - Python (in beta)
      - Splunk Distribution of OpenTelemetry Python version 1.15 or higher
+
+      Only CPU profiling is supported at the moment.
      - * :ref:`instrument-python-applications`
        * :ref:`profiling-configuration-python`
 


### PR DESCRIPTION
moved note about .net from node.js section to signalfx .net section (was in the wrong place); added note about cpu profiling for python

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
