### PR TITLE
Update advanced-python-otel-configuration.rst

### DIFF
--- a/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.rst
+++ b/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.rst
@@ -120,6 +120,8 @@ For backward compatibility with the SignalFx Python Tracing Library, use the b3m
 Python settings for AlwaysOn Profiling
 ====================================================
 
+.. note:: Only CPU profiling is supported at this time.
+
 The following settings control the AlwaysOn Profiling feature for the Python agent:
 
 .. list-table::

--- a/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.rst
+++ b/gdi/get-data-in/application/python/configuration/advanced-python-otel-configuration.rst
@@ -120,7 +120,7 @@ For backward compatibility with the SignalFx Python Tracing Library, use the b3m
 Python settings for AlwaysOn Profiling
 ====================================================
 
-.. note:: Only CPU profiling is supported at this time.
+.. note:: Only CPU profiling is supported.
 
 The following settings control the AlwaysOn Profiling feature for the Python agent:
 


### PR DESCRIPTION
added a note that only cpu profiling is supported at this time; see https://splunk.slack.com/archives/C01LWUBKZD1/p1711516152714349

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
