### PR TITLE
Update alias.rst

### DIFF
--- a/logs/alias.rst
+++ b/logs/alias.rst
@@ -51,6 +51,8 @@ For example, say Observability Cloud receives the following telemetry data:
 
 Although these refer to the same trace ID value, the log and the trace cannot be correlated in Observability Cloud because the field names, ``trace_id`` and ``trace.id`` do not match. In this case, alias your log metadata field ``trace.id`` to ``trace_id`` using Field Aliasing. When the field names in APM and Log Observer match, the trace and the log with the same trace ID value can be correlated in Observability Cloud. Then when you are viewing the trace in APM, you can click directly into the log with the same trace ID value and view the correlated log in Log Observer.
 
+To ensure full functionality of both Log Observer and Related Content, verify that your log fields are correctly mapped to the required key names as listed at :ref:`relatedcontent-log-observer`. 
+
 Normalizing field names
 --------------------------------------------------------------------------------
 One data source might have a field called ``http_referrer``. This field might be misspelled in your source data as ``http_referer``. Use field aliases to capture the misspelled field in your original source data and map it to the expected field name without modifying your logging code.


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ x] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**
Added a callout with link under Field Aliasing > Enabling Related Content to make apparent that there are additional key names besides trace_id and span_id that are required to enable related content for Log Observer. I've seen a few support cases dealing with this, so hoping to ensure all necessary information is easy to find. 
