### PR TITLE
splunk-otel-go requires Go 1.21

### DIFF
--- a/_includes/requirements/go.rst
+++ b/_includes/requirements/go.rst
@@ -1,1 +1,1 @@
-The Splunk Distribution of OpenTelemetry Go is compatible with Go 1.20 and higher.
+The Splunk Distribution of OpenTelemetry Go is compatible with Go 1.21 and higher.


### PR DESCRIPTION
Per https://github.com/signalfx/splunk-otel-go/pull/3102