### PR TITLE
Update configure-rum-android-instrumentation.rst

### DIFF
--- a/gdi/get-data-in/rum/android/configure-rum-android-instrumentation.rst
+++ b/gdi/get-data-in/rum/android/configure-rum-android-instrumentation.rst
@@ -64,7 +64,7 @@ Use the following settings to configure the Android RUM agent:
    * - :code:`enableSessionBasedSampling(double)`
      - Activates session ID based sampling and sets a sampling ratio. The sampling ratio is the probability of a session being included between. Values range between ``0.0`` (all dropped) and ``1.0`` (all included).
    * - :code:`enableDebug()`
-     - Activates debug mode. This feature is deactivated by default. Activating debug mode activates the OpenTelemetry logging span exporter, which might be useful when debugging instrumentation issues.
+     - Activates debug mode. This feature is inactive by default. Activating debug mode activates the OpenTelemetry logging span exporter, which might be useful when debugging instrumentation issues.
    * - :code:`enableExperimentalOtlpExporter()`
      - Activates the experimental OTLP exporter. The exporter is not compatible with disk buffering.
 


### PR DESCRIPTION
Just a single word change. "Inactive" makes it sound less like "something happened" instead of just starting out inactive.