### PR TITLE
add link to APM info

### DIFF
--- a/synthetics/browser-test/browser-test-results.rst
+++ b/synthetics/browser-test/browser-test-results.rst
@@ -143,7 +143,7 @@ Using the waterfall chart, you can do the following:
 - Expand the details in a row to show the request and response headers for that resource.
 - Hover over a row of the timeline to view a pop-up message with detailed request timings for that resource.
 - Search resources in a page by keywords in the URL.
-- Follow a direct link to related back-end spans if the same app is :new-page:`instrumented with APM <https://docs.splunk.com/observability/en/synthetics/set-up-synthetics/set-up-synthetics.html#optional-link-synthetic-spans-to-apm-spans>`.
+- Follow a direct link to related back-end spans if the same app is instrumented with APM. See :ref:`Link Synthetic spans to APM spans <synthetics-link-to-apm>`.
 - Use the tabs to filter the waterfall chart by resource type, including JS, CSS, Image, Media, JSON, and XML.
 - Download the raw HAR file, using the :new-page:`API <https://dev.splunk.com/observability/reference/api/synthetics_artifacts/latest#endpoint-getartifactsbytestid>`.
 - Show or hide columns in the chart

--- a/synthetics/browser-test/browser-test-results.rst
+++ b/synthetics/browser-test/browser-test-results.rst
@@ -143,7 +143,7 @@ Using the waterfall chart, you can do the following:
 - Expand the details in a row to show the request and response headers for that resource.
 - Hover over a row of the timeline to view a pop-up message with detailed request timings for that resource.
 - Search resources in a page by keywords in the URL.
-- Follow a direct link to related back end spans if the same app is :new-page:`instrumented with APM <https://docs.splunk.com/observability/en/synthetics/set-up-synthetics/set-up-synthetics.html#optional-link-synthetic-spans-to-apm-spans>`
+- Follow a direct link to related back-end spans if the same app is :new-page:`instrumented with APM <https://docs.splunk.com/observability/en/synthetics/set-up-synthetics/set-up-synthetics.html#optional-link-synthetic-spans-to-apm-spans>`.
 - Use the tabs to filter the waterfall chart by resource type, including JS, CSS, Image, Media, JSON, and XML.
 - Download the raw HAR file, using the :new-page:`API <https://dev.splunk.com/observability/reference/api/synthetics_artifacts/latest#endpoint-getartifactsbytestid>`.
 - Show or hide columns in the chart

--- a/synthetics/browser-test/browser-test-results.rst
+++ b/synthetics/browser-test/browser-test-results.rst
@@ -143,6 +143,7 @@ Using the waterfall chart, you can do the following:
 - Expand the details in a row to show the request and response headers for that resource.
 - Hover over a row of the timeline to view a pop-up message with detailed request timings for that resource.
 - Search resources in a page by keywords in the URL.
+- Follow a direct link to related back end spans if the same app is :new-page:`instrumented with APM <https://docs.splunk.com/observability/en/synthetics/set-up-synthetics/set-up-synthetics.html#optional-link-synthetic-spans-to-apm-spans>`
 - Use the tabs to filter the waterfall chart by resource type, including JS, CSS, Image, Media, JSON, and XML.
 - Download the raw HAR file, using the :new-page:`API <https://dev.splunk.com/observability/reference/api/synthetics_artifacts/latest#endpoint-getartifactsbytestid>`.
 - Show or hide columns in the chart


### PR DESCRIPTION
seeing the link to related back end spans in APM is part of interpreting browser test results

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ x] Content follows Splunk guidelines for style and formatting.
- [ x] You are contributing original content.

**Describe the change**

Adding a line to what is provided in the waterfall. Using the link to related back end spans in APM is part of interpreting browser test results