### PR TITLE
Update host-metrics-receiver.rst

### DIFF
--- a/gdi/opentelemetry/components/host-metrics-receiver.rst
+++ b/gdi/opentelemetry/components/host-metrics-receiver.rst
@@ -18,7 +18,6 @@ By default, the host metrics receiver is activated in the Splunk Distribution of
 - Memory usage metrics
 - Network interface and TCP connection metrics
 - Process count metrics (Linux only)
-- Per process CPU, memory, and disk I/O metrics
 
 Host receiver metrics appear in Infrastructure Monitoring. You can use them to create dashboards and alerts. See :ref:`create-detectors` for more information.
 


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

The `process` scraper is disabled by default in our configurations, so the doc needs to be updated to match.
[upstream agent config](https://github.com/signalfx/splunk-otel-collector/blob/7f6f08daadfcd603134589efbc8a26afa2335c78/cmd/otelcol/config/collector/upstream_agent_config.yaml#L49)
[full linux config](https://github.com/signalfx/splunk-otel-collector/blob/7f6f08daadfcd603134589efbc8a26afa2335c78/cmd/otelcol/config/collector/full_config_linux.yaml#L123)
[agent config](https://github.com/signalfx/splunk-otel-collector/blob/7f6f08daadfcd603134589efbc8a26afa2335c78/cmd/otelcol/config/collector/agent_config.yaml#L50)

This [caused some confusion](https://splunk.slack.com/archives/CQ17ZQJFP/p1716912889906629) so I believe we should remove. The scraper is referenced below in this doc, so users still know that it's available and know how to enable if they want the relevant metrics.