### PR TITLE
Update metrics-ootb-k8s.rst

### DIFF
--- a/gdi/opentelemetry/collector-kubernetes/metrics-ootb-k8s.rst
+++ b/gdi/opentelemetry/collector-kubernetes/metrics-ootb-k8s.rst
@@ -19,7 +19,7 @@ Learn more about the Collector's configuration and data processing at:
 * :ref:`otel-data-processing`
 * :ref:`signalfx-exporter`
 
-.. note:: In addition to the metrics shown on this page, most installations will also send metrics from the :ref:`../components/kubernetes-cluster-receiver`. Cluster Receiver metrics are an important part of monitoring any kubernets installation.  Refer to that page as well as the metrics listed here.
+.. note:: In addition to the metrics shown on this page, most instances also send metrics from the :ref:`kubernetes-cluster-receiver`. Cluster Receiver metrics are an important part of monitoring any kubernets installation. Refer to that page as well as the metrics listed here.
           
 To see the Collector's internal metrics, refer to :ref:`metrics-internal-collector`.
 

--- a/gdi/opentelemetry/collector-kubernetes/metrics-ootb-k8s.rst
+++ b/gdi/opentelemetry/collector-kubernetes/metrics-ootb-k8s.rst
@@ -19,7 +19,9 @@ Learn more about the Collector's configuration and data processing at:
 * :ref:`otel-data-processing`
 * :ref:`signalfx-exporter`
 
-.. note:: To see the Collector's internal metrics, refer to :ref:`metrics-internal-collector`.
+.. note:: In addition to the metrics shown on this page, most installations will also send metrics from the :ref:`../components/kubernetes-cluster-receiver`. Cluster Receiver metrics are an important part of monitoring any kubernets installation.  Refer to that page as well as the metrics listed here.
+          
+To see the Collector's internal metrics, refer to :ref:`metrics-internal-collector`.
 
 Container level metrics and dimensions
 ============================================================================


### PR DESCRIPTION
Added reference to cluster receiver metrics.  Most installations will also send cluster receiver metrics. In many cases the cluster receiver metrics will be as useful or more useful that the ones on this page.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
