### PR TITLE
Multiple apps in the same IIS App Pool can't use appSettings for configuration

### DIFF
--- a/gdi/get-data-in/application/otel-dotnet/instrumentation/instrument-dotnet-application.rst
+++ b/gdi/get-data-in/application/otel-dotnet/instrumentation/instrument-dotnet-application.rst
@@ -110,6 +110,9 @@ Windows
          .. note:: 
             If ``OTEL_SERVICE_NAME`` is not set for a web application hosted in IIS, the inferred name based on the site name and virtual directory path is used.
 
+         .. note:: 
+            If multiple applications are running in the same IIS Application Pool do not use the ``appSettings``. Let the instrumentation infer the name and use the Application Pool environment variables configuration, see below, to set the resource attributes.
+
          After modifying the web.config file, restart IIS:
 
          .. code-block:: powershell

--- a/gdi/get-data-in/application/otel-dotnet/instrumentation/instrument-dotnet-application.rst
+++ b/gdi/get-data-in/application/otel-dotnet/instrumentation/instrument-dotnet-application.rst
@@ -111,7 +111,7 @@ Windows
             If ``OTEL_SERVICE_NAME`` is not set for a web application hosted in IIS, the inferred name based on the site name and virtual directory path is used.
 
          .. note:: 
-            If multiple applications are running in the same IIS Application Pool do not use the ``appSettings``. Let the instrumentation infer the name and use the Application Pool environment variables configuration, see below, to set the resource attributes.
+            If multiple applications are running in the same IIS Application Pool do not use the ``appSettings`` block of the web.config file to configure any environment variable. Let the instrumentation infer the name and use the Application Pool environment variables configuration, see below, to set the resource attributes (which will be shared by all applications in the Application Pool).
 
          After modifying the web.config file, restart IIS:
 


### PR DESCRIPTION
See https://splunk.atlassian.net/browse/SWAT-7503?focusedCommentId=14928176 for detailed explanation.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
