### PR TITLE
Fix kafka permissions in AWS CloudWatch integrations

### DIFF
--- a/gdi/get-data-in/connect/aws/aws-prereqs.rst
+++ b/gdi/get-data-in/connect/aws/aws-prereqs.rst
@@ -107,7 +107,7 @@ Tag and property sync permissions:
 
 Tag and property sync is always activated for the services configured in the integration. For some services, Splunk Observability Cloud uses either service-specific APIs or generic APIs such as the Resource Groups Tagging API or Cloud Control API. 
 
-.. note:: The ``tag:GetResources`` permission is sufficient to use the Resource Groups Tagging API. If you're using the Cloud Control API, you need to provide permissions for ``cloudformation:ListResources`` and ``cloudformation:GetResource`` as well as service-specific permissions, for example,  ``kafka:DescribeClusterV2`` and ``kafka:ListClustersV2`` for AWS/Kafka.
+.. note:: The ``tag:GetResources`` permission is sufficient to use the Resource Groups Tagging API. If you're using the Cloud Control API, you need to provide permissions for ``cloudformation:ListResources`` and ``cloudformation:GetResource`` as well as service-specific permissions, for example,  ``kafka:DescribeCluster`` and ``kafka:ListClusters`` for AWS/Kafka.
 
 
 .. _aws-iam-policy-cw:
@@ -243,8 +243,8 @@ These are these permissions to allow Splunk Observability Cloud to collect AWS t
 - ``"elasticmapreduce:ListClusters"``
 - ``"es:DescribeElasticsearchDomain"``
 - ``"es:ListDomainNames"``
-- ``"kafka:DescribeClusterV2"``
-- ``"kafka:ListClustersV2"``
+- ``"kafka:DescribeCluster"``
+- ``"kafka:ListClusters"``
 - ``"kinesis:DescribeStream"``
 - ``"kinesis:ListShards"``
 - ``"kinesis:ListStreams"``
@@ -326,8 +326,8 @@ Add the ``"<service>:<permission>"`` pair relevant to each service in the ``Acti
           "elasticmapreduce:ListClusters",
           "es:DescribeElasticsearchDomain",
           "es:ListDomainNames",
-          "kafka:DescribeClusterV2",
-          "kafka:ListClustersV2",
+          "kafka:DescribeCluster",
+          "kafka:ListClusters",
           "kinesis:DescribeStream",
           "kinesis:ListShards",
           "kinesis:ListStreams",


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

V2 permissions are not needed for kafka tags/properties sync, V1 permissions (without version suffix) are required instead
