### PR TITLE
Update instrument-python-application.rst

### DIFF
--- a/gdi/get-data-in/application/python/instrumentation/instrument-python-application.rst
+++ b/gdi/get-data-in/application/python/instrumentation/instrument-python-application.rst
@@ -208,14 +208,14 @@ To send data directly to Splunk Observability Cloud, set the following environme
    .. code-tab:: bash Linux
 
       export SPLUNK_ACCESS_TOKEN=<access_token>
-      export OTEL_TRACES_EXPORTER=jaeger-thrift-splunk
-      export OTEL_EXPORTER_JAEGER_ENDPOINT=https://ingest.<realm>.signalfx.com/v2/trace
+      export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
+      export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://ingest.<realm>.signalfx.com/v2/trace/otlp
 
    .. code-tab:: shell Windows PowerShell
 
       $env:SPLUNK_ACCESS_TOKEN=<access_token>
-      $env:OTEL_TRACES_EXPORTER=jaeger-thrift-splunk
-      $env:OTEL_EXPORTER_JAEGER_ENDPOINT=https://ingest.<realm>.signalfx.com/v2/trace
+      $env:OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
+      $env:OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://ingest.<realm>.signalfx.com/v2/trace/otlp
 
 To obtain an access token, see :ref:`admin-api-access-tokens`.
 


### PR DESCRIPTION
**Requirements**

- [ X ] Content follows Splunk guidelines for style and formatting.
- [ X ] You are contributing original content.

**Describe the change**

When attempting to send traces directly from a Python app to o11y cloud, I discovered that splunk-opentelemetry[all] no longer includes the jaeger-thrift-splunk exporter, and thus the current guidance in the docs results in the following error:

`ValueError: exporter "jaeger-thrift-splunk (jaeger-thrift-splunk)" not found. please make sure the relevant exporter package is installed.`

I've proposed an alternative approach, which is aligned with [Send spans directly to Splunk Observability Cloud](https://docs.splunk.com/observability/en/gdi/get-data-in/serverless/aws/otel-lambda-layer/instrument-lambda-functions.html#send-spans-directly-to-splunk-observability-cloud) and worked fine in my testing. 
