### PR TITLE
Update linux-third-party.rst (Discovery mode)

### DIFF
--- a/gdi/opentelemetry/automatic-discovery/linux/linux-third-party.rst
+++ b/gdi/opentelemetry/automatic-discovery/linux/linux-third-party.rst
@@ -32,6 +32,8 @@ To discover any active and supported metric sources, run the following command o
 
     bin/otelcol --discovery --dry-run
 
+.. note:: discovery will require environment variables for `SPLUNK_REALM` and `SPLUNK_ACCESS_TOKEN` referencing your Splunk Observability realm (E.G. `us1`) and api token respectively. Or the use of the `--config <path_to_config_yaml>` option.
+
 The ``--dry-run`` option ensures that the resulting configuration isn't applied to the Collector at runtime. The sample configuration appears in the console as YAML instead. For example:
 
 .. code-block:: text

--- a/gdi/opentelemetry/automatic-discovery/linux/linux-third-party.rst
+++ b/gdi/opentelemetry/automatic-discovery/linux/linux-third-party.rst
@@ -32,7 +32,7 @@ To discover any active and supported metric sources, run the following command o
 
     bin/otelcol --discovery --dry-run
 
-.. note:: discovery will require environment variables for `SPLUNK_REALM` and `SPLUNK_ACCESS_TOKEN` referencing your Splunk Observability realm (E.G. `us1`) and api token respectively. Or the use of the `--config <path_to_config_yaml>` option.
+.. note:: Automatic discovery requires that environment variables ``SPLUNK_REALM`` and ``SPLUNK_ACCESS_TOKEN`` reference your Splunk Observability realm (for example ``us1``) and API token respectively. Alternatively, you can use the ``--config <path_to_config_yaml>`` option.
 
 The ``--dry-run`` option ensures that the resulting configuration isn't applied to the Collector at runtime. The sample configuration appears in the console as YAML instead. For example:
 


### PR DESCRIPTION
Upon startup of the splunk-otel-collector we do checks for the the `SPLUNK_REALM` and `SPLUNK_ACCESS_TOKEN` environment variables UNLESS a config is provided with `--config <path-to-config-yaml>`

This is the switch statement that controls the logic on if we check or not: https://github.com/signalfx/splunk-otel-collector/blob/d333bfcc3128d39cb846df95680a977c8161610f/internal/settings/settings.go#L473-L497

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
