### PR TITLE
Fixing public key typo for docker image verification

### DIFF
--- a/gdi/opentelemetry/install-the-collector.rst
+++ b/gdi/opentelemetry/install-the-collector.rst
@@ -72,7 +72,7 @@ If you need to verify and trust your software package, use the following public 
   VbbHBd5Xo9Ge5BjwXOcoDhvUQqNJdLBJruhvhn7Ogy5Paw5TGhdawfjxT2yXeqbE
   Juv6qdo/mSimkpR8lkQT7OsfAQbCPeyFvZKb22hXj6tCTVJncwCJLe/FBdXJhRep
   Y6NEdmKZLGodXv4zLNVr7SkCAwEAAQ==
-  -----END PUBLIC KEY----
+  -----END PUBLIC KEY-----
 
 For older Collector versions, use this public key: 
 


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

- I am a member of the Signing Service team at Splunk (Charlie Cai - this is my personal GitHub account). I previously copied the public key for signing verification and got some errors back. I noticed it was due to an incorrectly formatted public key (missing extra -).

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
