### PR TITLE
Update traces-spans.rst

### DIFF
--- a/apm/apm-spans-traces/traces-spans.rst
+++ b/apm/apm-spans-traces/traces-spans.rst
@@ -131,7 +131,7 @@ You can add custom span tags through the OpenTelemetry Collector, or when you in
 
 Span tags are most useful when they follow a simple, dependable system of naming conventions. See :ref:`span-tag-naming` to learn about OpenTelemetry naming conventions for span tags. 
 
-.. note:: Note that span tags in Splunk APM are distinct from metadata tags in Splunk Infrastructure Monitoring, which are searchable labels or keywords you can assign to metric dimensions in the form of strings rather than as key-value pairs. To learn more about metadata tags, see :ref:`metadata-infra-tags`.
+.. note:: Span tags in Splunk APM are distinct from metadata tags in Splunk Infrastructure Monitoring, which are searchable labels or keywords you can assign to metric dimensions in the form of strings rather than as key-value pairs. To learn more about metadata tags, see :ref:`metadata-infra-tags`.
 
 .. raw:: html
 


### PR DESCRIPTION
In the “Span tags” section of this page there is a “Note” information macro. I removed “Note that” and started off the sentence with “Span tags in Splunk APM…”

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
