### PR TITLE
Update java-servers-instructions.rst

### DIFF
--- a/gdi/get-data-in/application/java/instrumentation/java-servers-instructions.rst
+++ b/gdi/get-data-in/application/java/instrumentation/java-servers-instructions.rst
@@ -139,6 +139,8 @@ Add the path to the JVM agent to your Tomcat or TomEE startup script:
 
             set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"<Drive>:\path\to\splunk-otel-javaagent.jar"
 
+.. note:: For Tomcat instances running as Windows Services, add the ``-javaagent`` argument to the list of Java Options using the Tomcat9w GUI application. 
+
 .. _weblogic-javaagent:
 
 WebLogic


### PR DESCRIPTION
Added instructions for Tomcat instances running as Windows Services as setenv.bat won't work here.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ X ] Content follows Splunk guidelines for style and formatting.
- [ X ] You are contributing original content.

**Describe the change**

While working with a customer, I discovered that the current instructions of adding the javaagent argument to the setenv.bat doesn't work in the scenario where Tomcat is running as a Windows Service.  In this case, the Java Options need to be added using the Tomcat9w GUI application.  See https://stackoverflow.com/questions/73412601/increasing-allocated-memory-for-tomcat-didnt-work-using-setenv-bat for reference. 
