### PR TITLE
Update kubernetes-config-advanced.rst

### DIFF
--- a/gdi/opentelemetry/collector-kubernetes/kubernetes-config-advanced.rst
+++ b/gdi/opentelemetry/collector-kubernetes/kubernetes-config-advanced.rst
@@ -38,7 +38,7 @@ For example:
                 - key: k8s.pod.name
                   value: '^(podNameX)$'
       # Define the logs pipeline with the default values as well as your new processor component
-        service:
+      service:
         pipelines:
           logs:
             processors:


### PR DESCRIPTION
Fixing indentation error in line 41 for `service:` stanza.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

There was an indentation issue in of the examples in https://docs.splunk.com/observability/en/gdi/opentelemetry/collector-kubernetes/kubernetes-config-advanced.html specifically for line 41 stanza `service:`
