### PR TITLE
Update mssql-server-receiver.rst

### DIFF
--- a/gdi/opentelemetry/components/mssql-server-receiver.rst
+++ b/gdi/opentelemetry/components/mssql-server-receiver.rst
@@ -99,7 +99,7 @@ Enable built-in content
 
 Splunk Observability Cloud provides built-in dashboards with charts that give you immediate visibility into the technologies and services being used in your environment. Learn more at :ref:`collector-builtin-dashboard`.
 
-For the MS SQL Server receiver out-of-the-box content to work properly, you need to explicitly enable and disable specific metrics in your configuration file. See the configuration that enables built-in content at :new-page:`SQL Server discovery yaml <https://github.com/signalfx/splunk-otel-collector/blob/main/internal/confmapprovider/discovery/bundle/bundle.d/receivers/sqlserver.discovery.yaml>` in GitHub.
+For the MS SQL Server receiver out-of-the-box content to work properly, you need to explicitly enable and disable specific metrics and resource attributes in your configuration file. See the configuration that enables built-in content at :new-page:`SQL Server discovery yaml <https://github.com/signalfx/splunk-otel-collector/blob/main/internal/confmapprovider/discovery/bundle/bundle.d/receivers/sqlserver.discovery.yaml>` in GitHub.
 
 .. _mssql-server-receiver-settings:
 


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**
To properly include the SQL Server instance name resource attribute the user has to manually enable, as shown in the [referenced config file](https://github.com/signalfx/splunk-otel-collector/blob/b1524a03938062261e06ad1f14fb1dda2362f5cd/internal/confmapprovider/discovery/bundle/bundle.d/receivers/sqlserver.discovery.yaml#L17-L19). This allows the OOTB dashboard to query based on instance name.