### PR TITLE
Update instrument-java-application.rst

### DIFF
--- a/gdi/get-data-in/application/java/instrumentation/instrument-java-application.rst
+++ b/gdi/get-data-in/application/java/instrumentation/instrument-java-application.rst
@@ -259,11 +259,13 @@ If you need to send data directly to Splunk Observability Cloud, set the followi
 
       export SPLUNK_ACCESS_TOKEN=<access_token>
       export SPLUNK_REALM=<realm>
+      export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
 
    .. code-tab:: shell Windows PowerShell
 
       $env:SPLUNK_ACCESS_TOKEN=<access_token>
       $env:SPLUNK_REALM=<realm>
+      $env:OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
 
 To obtain an access token, see :ref:`admin-api-access-tokens`.
 


### PR DESCRIPTION
**Requirements**

- [ X ] Content follows Splunk guidelines for style and formatting.
- [ X ] You are contributing original content.

**Describe the change**

The Java 2.x agent uses http as the default protocol (vs. grpc for the 1.x agent).  To send traces directly to o11y cloud with the Java 2.x agent, we need to set the OTEL_EXPORTER_OTLP_TRACES_PROTOCOL environment variable to 'grpc'.  Otherwise, the export fails with the following error: 

`[otel.javaagent 2024-11-08 17:07:02:915 -0500] [OkHttp https://ingest.us1.signalfx.com/...] WARN io.opentelemetry.exporter.internal.http.HttpExporter - Failed to export spans. Server responded with HTTP status code 404.` 

This setting was tested as part of [this discussion](https://splunk.slack.com/archives/CQ17ZQJFP/p1731098770791089) on Slack. 