### PR TITLE
Update aws-prereqs.rst

### DIFF
--- a/gdi/get-data-in/connect/aws/aws-prereqs.rst
+++ b/gdi/get-data-in/connect/aws/aws-prereqs.rst
@@ -148,6 +148,8 @@ Note that the ``Version`` policy element defines the version of the policy langu
 .. _metricstreams_iampolicy:
 .. _aws-iam-policy-ms:
 
+.. note:: To ensure that API Gateway charts are fully populated, detailed CloudWatch metrics needs to be explicitly enabled.  Refer to :new-page:`Amazon API Gateway dimensions and metrics <https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html#api-gateway-metricdimensions>` for further guidance. 
+
 Permissions for Splunk-managed Metric Streams
 -----------------------------------------------------------
 

--- a/gdi/get-data-in/connect/aws/aws-prereqs.rst
+++ b/gdi/get-data-in/connect/aws/aws-prereqs.rst
@@ -144,11 +144,11 @@ For example:
   }
 
 Note that the ``Version`` policy element defines the version of the policy language. Learn more in Amazon's documentation at :new-page:`IAM JSON policy elements: Version <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_version.html>`.
-  
+
+.. note:: To ensure that API Gateway charts are fully populated, you need to explicity enable detailed CloudWatch metrics. Refer to :new-page:`Amazon API Gateway dimensions and metrics <https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html#api-gateway-metricdimensions>` for further guidance. 
+
 .. _metricstreams_iampolicy:
 .. _aws-iam-policy-ms:
-
-.. note:: To ensure that API Gateway charts are fully populated, detailed CloudWatch metrics needs to be explicitly enabled.  Refer to :new-page:`Amazon API Gateway dimensions and metrics <https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html#api-gateway-metricdimensions>` for further guidance. 
 
 Permissions for Splunk-managed Metric Streams
 -----------------------------------------------------------


### PR DESCRIPTION
**Requirements**

- [ X ] Content follows Splunk guidelines for style and formatting.
- [ X ] You are contributing original content.

**Describe the change**

While working with a customer I discovered that the API Gateway charts weren't lighting up as expected.  This is because the Method, Resource, and Stage dimensions were not being included with metrics such as Count, Latency, and 4XXError.  The solution was to enabled detailed CloudWatch metrics for each API Gateway stage of interest, as discussed in [Dimensions for metrics](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-metrics-and-dimensions.html#api-gateway-metricdimensions). 

Please let me know if you believe this should be noted in another area of the docs. 
