### PR TITLE
Update host-metrics-receiver.rst

### DIFF
--- a/gdi/opentelemetry/components/host-metrics-receiver.rst
+++ b/gdi/opentelemetry/components/host-metrics-receiver.rst
@@ -11,6 +11,7 @@ The host metrics receiver generates metrics scraped from host systems when the C
 
 By default, the host metrics receiver is activated in the Splunk Distribution of OpenTelemetry Collector and collects the following metrics:
 
+- System metrics
 - CPU usage metrics
 - Disk I/O metrics
 - CPU load metrics
@@ -89,6 +90,10 @@ Scrapers extract data from endpoints and then send that data to a specified targ
 
       - Scraper
       - Description
+   - 
+
+      - ``system``
+      - System metrics
    - 
 
       - ``cpu``


### PR DESCRIPTION
the latest release included the system scraper in the host metrics receiver which outputs the metric system.uptime (maybe more).  please consider changing the documentation on both default configuration files and the receiver documentation.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [ ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.

If this contribution is time sensitive, tell us when you'd like this PR to be merged.
