### PR TITLE
Update discovery-mode.rst

### DIFF
--- a/gdi/opentelemetry/discovery-mode.rst
+++ b/gdi/opentelemetry/discovery-mode.rst
@@ -75,7 +75,7 @@ Automatic discovery of third-party applications is supported in Linux and Kubern
      - Oracle DB receiver. See :ref:`oracledb`
 
    * - NGINX
-     - Smart Agent with collectd/nginx monitor type. See :ref:`nginx`
+     - NGINX receiver. See :ref:`nginx-receiver`
 
    * - RabbitMQ
      - RabbitMQ receiver. See :ref:`rabbitmq-receiver`.


### PR DESCRIPTION
Updating NGINX integration reference with changes made in v0.115.0 https://github.com/signalfx/splunk-otel-collector/pull/5689.

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

Automatic discovery for NGINX is now based on the OpenTelemetry receiver - this change reflects the same by linking to the NGINX receiver documentation.
