### PR TITLE
Update components.rst to correct aggretation to aggregation

### DIFF
--- a/gdi/opentelemetry/components.rst
+++ b/gdi/opentelemetry/components.rst
@@ -236,7 +236,7 @@ The Splunk Distribution of the OpenTelemetry Collector includes and supports the
      - Accepts spans, metrics, or logs and places them into batches. Batching helps better compress the data and reduce the number of outgoing connections required to transmit the data. This processor supports both size-based and time-based batching.
      - Metrics, logs, traces
    * - :ref:`cumulative-to-delta-processor` (``cumulativetodelta``)
-     - Convert cumulative monotonic metrics to delta aggretation temporality. This enhances the usage of cumulative metrics in Splunk Observability Cloud.
+     - Convert cumulative monotonic metrics to delta aggregation temporality. This enhances the usage of cumulative metrics in Splunk Observability Cloud.
      - Metrics
    * - :ref:`filter-processor` (``filter``)
      - Can be configured to include or exclude metrics based on metric name in the case of the ``strict`` or ``regexp`` match types, or based on other metric attributes in the case of the ``expr`` match type.


### PR DESCRIPTION
corrected "aggretation" to "aggregation" in definition of cumulative-to-delta-processor

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [X ] Content follows Splunk guidelines for style and formatting.
- [ ] You are contributing original content.

**Describe the change**

corrected "aggretation" to "aggregation" in definition of cumulative-to-delta-processor