### PR TITLE
Remove fluentforward

### DIFF
--- a/apm/profiling/get-data-in-profiling.rst
+++ b/apm/profiling/get-data-in-profiling.rst
@@ -286,7 +286,7 @@ Follow these steps to set up AlwaysOn Profiling with a collector in data forward
       service:
          pipelines:
             logs:
-               receivers: [fluentforward, otlp]
+               receivers: [otlp]
                processors:
                - memory_limiter
                - batch


### PR DESCRIPTION
We don't want to specify fluentforward for logs any more.