### PR TITLE
Update chrony-receiver.rst

### DIFF
--- a/gdi/opentelemetry/components/chrony-receiver.rst
+++ b/gdi/opentelemetry/components/chrony-receiver.rst
@@ -45,7 +45,7 @@ Next, include the receiver in the ``metrics`` pipeline of the ``service`` sectio
     pipelines:
       metrics:
         receivers:
-          - chrony
+          - chrony/defaults
 
 Advanced configuration
 -----------------------------------------------


### PR DESCRIPTION
fixing typo on the pipeline's receiver name

<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x ] You are contributing original content.

**Describe the change**

Enter a description of the changes, why they're good for the Observability Cloud documentation, and so on.
Just fixing a typo that creates a mismatch between the receiver name and the pipeline's receiver name
If this contribution is time sensitive, tell us when you'd like this PR to be merged.
