### PR TITLE
Update action value for correctness

### DIFF
--- a/gdi/opentelemetry/components/otlphttp-exporter.rst
+++ b/gdi/opentelemetry/components/otlphttp-exporter.rst
@@ -142,7 +142,7 @@ For example:
   extensions:
     headers_setter:
       headers:
-        - action: insert
+        - action: upsert
           key: X-SF-TOKEN
           from_context: X-SF-TOKEN
 


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

`upsert` properly inserts the access token if the key doesn't already exist, or overwrites an existing value. `insert` will not overwrite the existing value, meaning an incorrect access token may be used. ([Documentation on `insert` vs. `upsert`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/headerssetterextension#configuration))