### PR TITLE
Remove note about retired SignalFx .NET instrumentation

### DIFF
--- a/gdi/opentelemetry/automatic-discovery/windows/windows-backend.rst
+++ b/gdi/opentelemetry/automatic-discovery/windows/windows-backend.rst
@@ -9,8 +9,6 @@ Zero-code instrumentation for back-end applications in Windows
 
 Automatic discovery for OpenTelemetry .NET activates zero-code instrumentation for .NET applications running on Windows. By default, zero-code instrumentation is only turned on for IIS applications. To activate other application and service types, see :ref:`otel-dotnet-manual-install`. After installing the package, you must start or restart any .NET applications that you want to instrument. 
 
-.. note:: The SignalFx instrumentation for .NET is deprecated and will reach end of support on February 21, 2025. To learn how to migrate from SignalFx .NET to OpenTelemetry .NET, see :ref:`migrate-signalfx-dotnet-to-dotnet-otel`.
-
 Get started
 ==================================================
 


### PR DESCRIPTION
The note gives the impression that SignalFx is still somehow deployed or relevant.
