### PR TITLE
Prepare Splunk Add-On for the OpenTelemetry Collector release notes 1.4.1

### DIFF
--- a/gdi/opentelemetry/collector-addon/collector-addon-release-notes.rst
+++ b/gdi/opentelemetry/collector-addon/collector-addon-release-notes.rst
@@ -20,6 +20,14 @@ Release Notes for the Splunk Add-On for the OpenTelemetry Collector
       - Release date
       - Collector version
 
+   *  - 1.4.1 
+      - November 7, 2024
+      - :new-page:`version 0.111 <https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.120.0>`
+
+   *  - 1.4.0 
+      - November 7, 2024
+      - :new-page:`version 0.111 <https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.118.0>`
+
    *  - 1.3.3 
       - November 7, 2024
       - :new-page:`version 0.111 <https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.111.0>`

--- a/gdi/opentelemetry/collector-addon/collector-addon-release-notes.rst
+++ b/gdi/opentelemetry/collector-addon/collector-addon-release-notes.rst
@@ -21,7 +21,7 @@ Release Notes for the Splunk Add-On for the OpenTelemetry Collector
       - Collector version
 
    *  - 1.4.1 
-      - November 7, 2024
+      - April 2, 2025
       - :new-page:`version 0.111 <https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.120.0>`
 
    *  - 1.4.0 


### PR DESCRIPTION
- Soon we will be releasing OpenTelemetry Collector release notes 1.4.1. Approvals are appreciated, but do not merge until this PR is no longer a draft.
- Prepared Splunk Add-On for the OpenTelemetry Collector release notes 1.4.1, also included missing 1.4.0 notes.
