### PR TITLE
Update kubernetes-config.rst with operator guidance for Windows nodes

### DIFF
--- a/gdi/opentelemetry/collector-kubernetes/kubernetes-config.rst
+++ b/gdi/opentelemetry/collector-kubernetes/kubernetes-config.rst
@@ -305,3 +305,13 @@ Deactivate the ``clusterReceiver`` on one of the installations to avoid cluster-
 
   clusterReceiver:
     enabled: false
+
+If using the operator, it should be enabled in the Linux configuration only, and it should include a node selector to ensure it targets Linux nodes only: 
+
+.. code-block:: yaml
+
+  operator:
+    enabled: true
+    nodeSelector:
+      kubernetes.io/os: linux
+


### PR DESCRIPTION
**Requirements**

- [X] Content follows Splunk guidelines for style and formatting.
- [X] You are contributing original content.

**Describe the change**

When deploying the collector in a K8s cluster with both Linux and Windows nodes, where the operator is enabled, we need to add a node selector to ensure that the operator is deployed to a Linux node, as it will not work if deployed to a Windows node.  I've tested this change in an AKS environment with Linux and Windows nodes. 