### PR TITLE
Updated otel linux requirements - removed Oracle 7

### DIFF
--- a/_includes/requirements/collector-linux.rst
+++ b/_includes/requirements/collector-linux.rst
@@ -1,7 +1,8 @@
 The Collector supports the following Linux distributions and versions:
 
 * Amazon Linux: 2, 2023. Log collection with Fluentd is not currently supported for Amazon Linux 2023.
-* CentOS, Red Hat, or Oracle: 7, 8, 9
+* CentOS, or Red Hat: 7, 8, 9
+* Oracle: 8, 9
 * Debian: 11, 12
 * SUSE: 12, 15 for version 0.34.0 or higher. Log collection with Fluentd is not currently supported.
 * Ubuntu: 16.04, 18.04, 20.04, 22.04, and 24.04

--- a/gdi/opentelemetry/collector-linux/deployments-linux-ansible.rst
+++ b/gdi/opentelemetry/collector-linux/deployments-linux-ansible.rst
@@ -15,7 +15,8 @@ Install the Ansible collection
 The following Linux distributions and versions are supported:
 
 * Amazon Linux: 2, 2023. Log collection with Fluentd isn't supported for Amazon Linux 2023.
-* CentOS, Red Hat, or Oracle: 7, 8, 9
+* CentOS, or Red Hat: 7, 8, 9
+* Oracle: 8, 9
 * Debian: 11, 12
 * SUSE: 12, 15 for Collector version 0.34.0 or higher. Log collection with Fluentd isn't supported.
 * Ubuntu: 16.04, 18.04, 20.04, and 22.04

--- a/gdi/opentelemetry/collector-linux/deployments-linux-chef.rst
+++ b/gdi/opentelemetry/collector-linux/deployments-linux-chef.rst
@@ -29,7 +29,8 @@ Linux
 The following Linux distributions and versions:
 
 * Amazon Linux: 2
-* CentOS, Red Hat, Oracle: 7, 8, 9
+* CentOS, Red Hat: 7, 8, 9
+* Oracle: 8, 9
 * Debian: 11, 12
 * SUSE: 12, 15 (Note: Only for Collector versions 0.34.0 or higher. Log collection with Fluentd not currently supported.)
 * Ubuntu: 18.04, 20.04, 22.04

--- a/gdi/opentelemetry/collector-linux/deployments-linux-puppet.rst
+++ b/gdi/opentelemetry/collector-linux/deployments-linux-puppet.rst
@@ -13,7 +13,8 @@ Use this module to install and configure the Collector on Linux. Download and in
 Currently, we support the following Linux distributions and versions:
 
 - Amazon Linux: 2, 2023. Log collection with Fluentd isn't supported for Amazon Linux 2023.
-- CentOS / Red Hat / Oracle: 7, 8, 9
+- CentOS / Red Hat: 7, 8, 9
+- Oracle: 8, 9
 - Debian: 11, 12
 - SUSE: 12, 15 (Note: Only applicable for Collector versions v0.34.0 or higher. Log collection with Fluentd not currently supported.)
 - Ubuntu: 16.04, 18.04, 20.04, 22.04

--- a/gdi/opentelemetry/collector-linux/deployments-linux-salt.rst
+++ b/gdi/opentelemetry/collector-linux/deployments-linux-salt.rst
@@ -29,7 +29,8 @@ Supported Linux versions
 The following Linux distributions and versions are supported:
 
 * Amazon Linux: 2, 2023. Log collection with Fluentd isn't supported for Amazon Linux 2023.
-* CentOS, Red Hat, Oracle: 7, 8, 9
+* CentOS, Red Hat: 7, 8, 9
+* Oracle: 8, 9
 * Debian: 11, 12
 * SUSE: 12, 15 (Note: Only for Collector versions 0.34.0 or higher. Log collection with Fluentd not currently supported.)
 * Ubuntu: 18.04, 20.04, 22.04


### PR DESCRIPTION
<!--// 
Thanks for your contribution! Please fill out the following template. Do not post private or sensitive information.
For more information, see our Contribution guidelines.
//-->

**Requirements**

- [x] Content follows Splunk guidelines for style and formatting.
- [x] You are contributing original content.

**Describe the change**

Updated otel linux requirements - removed Oracle 7 support for Linux since latest release dropped support for Oracle 7 - https://github.com/signalfx/splunk-otel-collector/releases/tag/v0.121.0
