### PR TITLE
Fix Send data directly to Splunk Observability Cloud

### DIFF
--- a/gdi/get-data-in/application/go/instrumentation/instrument-go-application.rst
+++ b/gdi/get-data-in/application/go/instrumentation/instrument-go-application.rst
@@ -179,7 +179,6 @@ If you need to send data directly to Splunk Observability Cloud, set the followi
 
       export SPLUNK_ACCESS_TOKEN=<access_token>
       export SPLUNK_REALM=<realm>
-      export OTEL_METRICS_EXPORTER=none
 
    .. code-tab:: shell Windows PowerShell
 


### PR DESCRIPTION
Setting OTEL_METRICS_EXPORTER=none is disabling exporting metrics to Splunk Observability Cloud

I think this setting was supposed to be temporary when there was no OTLP metrics endpoint in Splunk Observability Cloud.