### PR TITLE
Fix token related error while adding PR comment

### DIFF
--- a/.github/workflows/heretto-reminder.yml
+++ b/.github/workflows/heretto-reminder.yml
@@ -17,7 +17,20 @@ jobs:
 
 
     steps:
+      - name: Add PR label
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['heretto']
+            })
       - name: Add PR Comment
+        if: ${{ github.head_ref == 'repo-sync' }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.MY_TOKEN }}


### PR DESCRIPTION
**Describe the change**
Failing action https://github.com/splunk/public-o11y-docs/actions/runs/15490506134
Add label on PR from forked repository branch
Add comment on PR from splunk/public-o11y-docs branch

@jcatera I'd like to propose this change regarding not commenting on non repo-sync PR's. PTAL