### PR TITLE
GitHub archive reminder 

### DIFF
--- a/.github/workflows/archive-reminder.yml
+++ b/.github/workflows/archive-reminder.yml
@@ -1,4 +1,4 @@
-name: Heretto Update Reminder
+name: Splunk Observability Cloud GitHub repository archive reminder
 
 on:
   pull_request:
@@ -35,5 +35,5 @@ jobs:
               owner,
               repo,
               issue_number: number,
-              body: `@${author}, please make sure that you update the files in Heretto and post the Heretto share link in this PR.`
+              body: `@${author}, please note this GitHub repository will be archived on August 30, 2025. On July 1st, no new contributors will be added to the repository, and only contributors with prior contributions will be able to make pull requests (PRs). From August 1st to August 30th, only Collaborators and Organization members will be able to create PRs.`
             })


### PR DESCRIPTION
This PR has a GitHub workflow that posts a message that this GitHub repository will be archived. The message also communicates who will be able to contribute before the GitHub repository is archived.